### PR TITLE
Xbox_360_Wireless_Receiver.cfg

### DIFF
--- a/udev/Xbox_360_Wireless_Receiver.cfg
+++ b/udev/Xbox_360_Wireless_Receiver.cfg
@@ -1,5 +1,7 @@
 input_device = "Xbox 360 Wireless Receiver"
 input_driver = "udev"
+input_vendor_id = 1118
+input_product_id = 654
 input_b_btn = "0"
 input_y_btn = "2"
 input_select_btn = "6"


### PR DESCRIPTION
Remove duplicate key bindings for input_exit_emulator_btn and input_enable_hotkey_btn causing emulator to exit when pressing start.
