### PR TITLE
Update and rename FC30_Gamepad.cfg to 8Bitdo FC30 GamePad.cfg

### DIFF
--- a/android/8Bitdo FC30 GamePad.cfg
+++ b/android/8Bitdo FC30 GamePad.cfg
@@ -1,8 +1,11 @@
-input_device = "8Bitdo FC30"
+input_vendor_id = 10256
+input_product_id = 9
+input_device = "8Bitdo FC30 GamePad"
+input_device_display_name = "8Bitdo FC30 GamePad"
 input_driver = "android"
 input_b_btn = "97"
 input_y_btn = "100"
-input_select_btn = "98"
+input_select_btn = "109"
 input_start_btn = "108"
 input_up_btn = "19"
 input_down_btn = "20"


### PR DESCRIPTION
- Renamed file to match the other 8Bitdo autoconfig file names
- Added VID/PID
- Added display name
- Fixed SELECT button code