### PR TITLE
Update DragonRise_Inc._PC_TWIN_SHOCK_Gamepad.cfg

### DIFF
--- a/udev/DragonRise_Inc._PC_TWIN_SHOCK_Gamepad.cfg
+++ b/udev/DragonRise_Inc._PC_TWIN_SHOCK_Gamepad.cfg
@@ -1,4 +1,4 @@
-input_device = "DragonRise Inc.   Generic   USB  Joystick  "
+input_device = "DragonRise Inc. PC TWIN SHOCK Gamepad"
 input_driver = "udev"
 input_vendor_id = 121
 input_product_id = 6


### PR DESCRIPTION
Alter the `input_device` value to match the filename.
This is the value that appears on the `lsusb` command.
It seems that this file was copied from `DragonRise_Inc.___Generic___USB__Joystick__.cfg`
and not altered his `input_device` value.