### PR TITLE
Update 8Bitdo_ZERO_BT.cfg

### DIFF
--- a/udev/8Bitdo_ZERO_BT.cfg
+++ b/udev/8Bitdo_ZERO_BT.cfg
@@ -7,14 +7,28 @@ input_device_display_name = "8Bitdo ZERO BT"
 input_vendor_id = 1440
 input_product_id = 12850
 
-input_b_btn = "11"
-input_y_btn = "14"
-input_select_btn = "21"
-input_start_btn = "22"
-input_a_btn = "12"
-input_x_btn = "15"
-input_l_btn = "17"
-input_r_btn = "18"
+# Newest mapping: Latest released 8Bitdo Zero GamePad
+# Bluetooth Mode(START) D-pad = PC Joystick
+input_b_btn = "0"
+input_y_btn = "3"
+input_select_btn = "10"
+input_start_btn = "11"
+input_a_btn = "1"
+input_x_btn = "4"
+input_l_btn = "6"
+input_r_btn = "7"
+
+# Alternative mapping: Early released 8Bitdo Zero GamePad
+# Bluetooth Mode(START) D-pad = Keyboard arrow keys
+# Bluetooth Mode(START+R) D-pad = PC Joystick
+#input_b_btn = "11"
+#input_y_btn = "14"
+#input_select_btn = "21"
+#input_start_btn = "22"
+#input_a_btn = "12"
+#input_x_btn = "15"
+#input_l_btn = "17"
+#input_r_btn = "18"
 
 input_b_btn_label = "A"
 input_y_btn_label = "X"
@@ -25,18 +39,7 @@ input_x_btn_label = "Y"
 input_l_btn_label = "L"
 input_r_btn_label = "R"
 
-# Bluetooth Mode(START) D-pad = Keyboard arrow keys
-input_up_btn = "0"
-input_down_btn = "5"
-input_left_btn = "2"
-input_right_btn = "3"
-
-input_up_btn_label = "D-Pad Up"
-input_down_btn_label = "D-Pad Down"
-input_left_btn_label = "D-Pad Left"
-input_right_btn_label = "D-Pad Right"
-
-# Bluetooth Mode(START+R) D-pad = PC Joystick
+# D-pad = PC Joystick
 input_up_axis = "-1"
 input_down_axis = "+1"
 input_left_axis = "-0"
@@ -52,4 +55,3 @@ input_right_axis_label = "D-Pad Right"
 # fix it by adding this udev rule (the line below WITHOUT the # symbol at the beginning!) to "/etc/udev/rules.d/10-local.rules" and reboot.
 # SUBSYSTEM=="input", ATTRS{name}=="8Bitdo Zero GamePad", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
 # -------------------------------------------------------------------------------------------------------------------------------------------------
-


### PR DESCRIPTION
I have two zero gamepads, one blue colored (bought when it was introduced) and one famicom edition (red colored). They both is identified as "8Bitdo Zero GamePad" with Decimal vid:pid = 1440:12850, but they have different mappings. There is no firmware release available and I'm not sure if there is different mappings of the blue colored gamepad or if the difference is only blue colored vs. famicom edition.