### PR TITLE
Create Retrolink_(S)NES_USB.cfg

### DIFF
--- a/xinput/Retrolink_(S)NES_USB.cfg
+++ b/xinput/Retrolink_(S)NES_USB.cfg
@@ -1,0 +1,33 @@
+input_device = "Retrolink classic (S)NES USB"
+input_device_display_name = "Retrolink classic controller"
+
+input_driver = "xinput"
+
+input_vendor_id = 121
+input_product_id = 17
+
+input_b_btn = "2"
+input_y_btn = "3"
+input_select_btn = "8"
+input_start_btn = "9"
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_a_btn = "1"
+input_x_btn = "0"
+input_l_btn = "4"
+input_r_btn = "5"
+
+input_b_btn_label = "B"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_up_axis_label = "Up"
+input_down_axis_label = "Down"
+input_left_axis_label = "Left"
+input_right_axis_label = "Right"
+input_a_btn_label = "A"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"


### PR DESCRIPTION
Config file for both the retrolink NES and retrolink SNES controller. The controllers both use the same product id as retrolink is known to do. However the NES controller maps it keys to the same scancode as the SNES controller does, so this config works for these two controllers, Other products or future products by retrolink using the same product id may be a problem.