### PR TITLE
Updated DragonRise PID 6

### DIFF
--- a/udev/DragonRise_Inc.___Generic___USB__Joystick__.cfg
+++ b/udev/DragonRise_Inc.___Generic___USB__Joystick__.cfg
@@ -1,28 +1,90 @@
+# 0079:0006 DragonRise Inc.   Generic   USB  Joystick  
+
+# There are a number of controllers that all share the same generic Chinese
+# USB gamepad encoder chip and therefor identify themselves the same.
+# Most of them share the same "dual shock" layout but replace the
+# triangle/circle/cross/square symbols with the numbers 1/2/3/4, but there are
+# exceptions that require a different mapping like the "Retrolink N64 USB
+# controller".
+
+# The same USB encoder is also used in the "Bosega Game Control Board", a PCB
+# commonly sold as "Zero delay USB encoder" for use in custom built arcade
+# sticks. As there is little guidance on how to wire the buttons to this board
+# there may be many variations out there.
+
+# The recommended way to wire an 8-button compatible arcade stick is shown
+# below (using the names from the solder side of the board). The reason R1/R2
+# are placed to the left of L1/L2 is that on a gamepad R1 and R2 are the most
+# natural way to extend the 4 surface buttons to a 6 button cluster.
+# You should also wire up the MODE button to be able to switch the joystick to
+# d-pad mode as opposed to the default which is left analog stick.
+
+#  SE ST
+# K4 K1 R1 L1
+# K3 K2 R2 L2
+
+# Note that the linux kernel driver for this controller was broken from
+# kernel 4.4 until 4.9. With the broken driver the joystick axes
+# numbers will be off. This can be fixed by reverting commit
+# 18339f59c3a6698ee17d32970c9e1e450b16e7c3 and rebuilding hid-dr.ko.
+
 input_device = "DragonRise Inc.   Generic   USB  Joystick  "
 input_driver = "udev"
 input_vendor_id = 121
 input_product_id = 6
+
+#########
+
+input_x_btn = "0"
+input_a_btn = "1"
 input_b_btn = "2"
 input_y_btn = "3"
-input_select_btn = "8"
-input_start_btn = "9"
-input_up_btn = "h0up"
-input_down_btn = "h0down"
-input_left_btn = "h0left"
-input_right_btn = "h0right"
-input_a_btn = "1"
-input_x_btn = "0"
 input_l_btn = "4"
 input_r_btn = "5"
 input_l2_btn = "6"
 input_r2_btn = "7"
+input_select_btn = "8"
+input_start_btn = "9"
 input_l3_btn = "10"
 input_r3_btn = "11"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
 input_l_x_plus_axis = "+0"
 input_l_x_minus_axis = "-0"
 input_l_y_plus_axis = "+1"
 input_l_y_minus_axis = "-1"
-input_r_x_plus_axis = "+3"
-input_r_x_minus_axis = "-3"
-input_r_y_plus_axis = "+4"
-input_r_y_minus_axis = "-4"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
+
+#########
+
+input_x_btn_label = "1"
+input_a_btn_label = "2"
+input_b_btn_label = "3"
+input_y_btn_label = "4"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "L2"
+input_r2_btn_label = "R2"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_l3_btn_label = "L3"
+input_r3_btn_label = "R3"
+
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"
+input_l_x_plus_axis_label = "Left Analog X+"
+input_l_x_minus_axis_label = "Left Analog X-"
+input_l_y_plus_axis_label = "Left Analog Y+"
+input_l_y_minus_axis_label = "Left Analog Y-"
+input_r_x_plus_axis_label = "Right Analog X+"
+input_r_x_minus_axis_label = "Right Analog X-"
+input_r_y_plus_axis_label = "Right Analog Y+"
+input_r_y_minus_axis_label = "Right Analog Y-"


### PR DESCRIPTION
This configuration is for multiple controllers sharing the same USB
encoder.

Added button names for the most common naming of these gamepads.
Added information about the chip and controller variations sharing the
same USB ID.
Corrected mapping of right analog stick.
