### PR TITLE
udev: Updated Dragonrise 0079:0011

### DIFF
--- a/udev/DragonRise Inc. Gamepad.cfg
+++ b/udev/DragonRise Inc. Gamepad.cfg
@@ -1,34 +1,53 @@
+# 0079:0011 DragonRise Inc. Gamepad
+
+# There are a number of controllers that all share the same generic USB
+# encoder chip and therefor identify themselves the same.
+# Most share a common layout modeled after the original PlayStation gamepad,
+# but there are variations such as the "Retrolink Sega Saturn USB GamePad" that
+# are vastly different.
+# It seems that some variations swap L with L2 and R with R2
+# This configuration file follows the mapping that is most commonly used by
+# gamepads in general. (action buttons enumerated clockwise)
+# 1 2 3 4 L R L2 R2 Se St
+
 input_driver = "udev"
-input_device = "DragonRise Inc. Gamepad"
-input_vendor_id = "121"
-input_product_id = "17"
-input_select_btn = "8"
-input_start_btn = "9"
-input_l_btn = "6"
-input_r_btn = "7"
-input_l2_btn = "4"
-input_r2_btn = "5"
+input_vendor_id = 121
+input_product_id = 17
+input_device = "USB Gamepad "
+input_device_display_name = "DragonRise generic PlayStation gamepad"
+
+#########
+
+input_x_btn = "0"
+input_a_btn = "1"
 input_b_btn = "2"
 input_y_btn = "3"
-input_up_axis = "-1"
-input_down_axis = "+1"
+input_l_btn = "4"
+input_r_btn = "5"
+input_l2_btn = "6"
+input_r2_btn = "7"
+input_select_btn = "8"
+input_start_btn = "9"
+
 input_left_axis = "-0"
 input_right_axis = "+0"
-input_a_btn = "1"
-input_x_btn = "0"
+input_up_axis = "-1"
+input_down_axis = "+1"
 
-input_device_display_name = "DragonRise Inc. Gamepad"
-input_x_btn_label = "1"
-input_a_btn_label = "2"
-input_b_btn_label = "3"
-input_y_btn_label = "4"
-input_select_btn_label = "Select"
-input_start_btn_label = "Start"
-input_up_axis_label = "D-Pad Up"
-input_down_axis_label = "D-Pad Down"
-input_left_axis_label = "D-Pad Left"
-input_right_axis_label = "D-Pad Right"
+#########
+
+input_x_btn_label = "1/Triangle"
+input_a_btn_label = "2/Circle"
+input_b_btn_label = "3/Cross"
+input_y_btn_label = "4/Square"
 input_l_btn_label = "L1"
 input_r_btn_label = "R1"
 input_l2_btn_label = "L2"
 input_r2_btn_label = "R2"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"


### PR DESCRIPTION
There are three separate configuration files for Dragonrise 0079:0011.
Two of them used to have identical button mappings but one of them used
the VID:PID string "Dragonrise Inc. Gamepad" instead of the proper
iProduct string "USB Gamepad " as device_name.

This was corrected and button layout was changed to a more common layout
in that variant of the configuration file. 

note that this is yet another example of this issue:
https://github.com/libretro/RetroArch/issues/3914
