### PR TITLE
Add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+DESTDIR := /tmp/retroarch-joypad-autoconfig
+
+all:
+	@echo "Nothing to make for retroarch-joypad-autoconfig."
+
+install:
+	mkdir -p $(DESTDIR)
+	cp -ar * $(DESTDIR)
+	rm $(DESTDIR)/Makefile
+	rm $(DESTDIR)/configure

--- a/configure
+++ b/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PACKAGE_NAME=retroarch-joypad-autoconfig


### PR DESCRIPTION
The `./configure` and `make` tasks allow the joypad configuration to be installed to the given `DESTDIR`. This will be used in FlatPak to allow packaging and distribution.