### PR TITLE
Fix Xbox 360 Controller for SDL2

### DIFF
--- a/sdl2/X360 Controller.cfg
+++ b/sdl2/X360 Controller.cfg
@@ -1,5 +1,13 @@
+# XInput Controller
+# Hex vid:pid = 045e:028e
+
+input_device_display_name = "Xbox 360 Controller"
+
 input_driver = "sdl2"
-input_device = "X360 Controller"
+input_device = "XInput Controller"
+input_vendor_id = "1118"
+input_product_id = "654"
+
 input_b_btn = "0"
 input_y_btn = "2"
 input_select_btn = "4"


### PR DESCRIPTION
This adds a few device settings for the Xbox 360 controller allowing it to work autodetect under SDL2.