### PR TITLE
Fix DESTDIR, and add INSTALLDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-DESTDIR := /tmp/retroarch-joypad-autoconfig
+INSTALLDIR := /usr/share/libretro/autoconfig
 
 all:
 	@echo "Nothing to make for retroarch-joypad-autoconfig."
 
 install:
-	mkdir -p $(DESTDIR)
-	cp -ar * $(DESTDIR)
-	rm $(DESTDIR)/Makefile
-	rm $(DESTDIR)/configure
+	mkdir -p $(DESTDIR)$(INSTALLDIR)
+	cp -ar * $(DESTDIR)$(INSTALLDIR)
+	rm -rf $(DESTDIR)$(INSTALLDIR)/Makefile \
+		$(DESTDIR)$(INSTALLDIR)/configure
+
+test-install: all
+	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
`DESTDIR` is the root of the file system, not where the package should be installed. This introduces a `INSTALLDIR` to allow changing install destination.

https://www.gnu.org/prep/standards/html_node/DESTDIR.html