### PR TITLE
hid: Add Mayflash Wii Classic Controller Adapter

### DIFF
--- a/hid/Mayflash_Wii_Classic_Controller_Adapter.cfg
+++ b/hid/Mayflash_Wii_Classic_Controller_Adapter.cfg
@@ -1,0 +1,69 @@
+# Mayflash Wii Classic Controller Adapter For PC
+# http://www.mayflash.com
+# http://www.mayflash.com/products/pcusb/pc052.html
+input_driver = "hid"
+input_device = "Dual Box WII"
+input_device_display_name = "Wii Classic Controller Adapter"
+
+input_vendor_id = "7545"
+input_product_id = "769"
+
+input_select_btn = "9"
+input_start_btn = "10"
+
+input_a_btn = "2"
+input_b_btn = "3"
+input_x_btn = "1"
+input_y_btn = "4"
+
+input_up_btn = "13"
+input_down_btn = "15"
+input_left_btn = "16"
+input_right_btn = "14"
+
+input_l_btn = "7"
+input_r_btn = "8"
+input_l2_btn = "5"
+input_r2_btn = "6"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+
+input_r_x_plus_axis = "+4"
+input_r_x_minus_axis = "-4"
+input_r_y_plus_axis = "+5"
+input_r_y_minus_axis = "-5"
+
+input_menu_toggle_btn = "11"
+
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+
+input_a_btn_label = "A"
+input_b_btn_label = "B"
+input_x_btn_label = "X"
+input_y_btn_label = "Y"
+
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "ZL"
+input_r2_btn_label = "ZR"
+
+input_up_btn_label = "D-pad Up"
+input_down_btn_label = "D-pad Down"
+input_left_btn_label = "D-pad Left"
+input_right_btn_label = "D-pad Right"
+
+input_l_x_plus_axis_label = "LS Right"
+input_l_x_minus_axis_label = "LS Left"
+input_l_y_plus_axis_label = "LS Down"
+input_l_y_minus_axis_label = "LS Up"
+
+input_r_x_plus_axis_label = "RS Right"
+input_r_x_minus_axis_label = "RS Left"
+input_r_y_plus_axis_label = "RS Down"
+input_r_y_minus_axis_label = "RS Up"
+
+input_menu_toggle_btn_label = "Home"


### PR DESCRIPTION
This USB controller adapter has 2 ports and presents itself as 2 devices to Retroarch.
There seems to be a race on which port gets to be device `#0` and which gets to be device `#1`

http://www.mayflash.com/products/pcusb/pc052.html