### PR TITLE
Update and rename raphnet.net_4nes4snes.cfg to raphnet.net_4nes4snes_…

### DIFF
--- a/udev/raphnet.net_4nes4snes_v1.5.cfg
+++ b/udev/raphnet.net_4nes4snes_v1.5.cfg
@@ -1,4 +1,4 @@
-input_device = "raphnet.net 4nes4snes"
+input_device = "raphnet.net 4nes4snes v1.5"
 input_driver = "udev"
 
 input_vendor_id = 6017


### PR DESCRIPTION
To avoid confusion, this version has a different product ID.