### PR TITLE
adding GameStick Controller config

### DIFF
--- a/udev/GameStick Controller.cfg
+++ b/udev/GameStick Controller.cfg
@@ -1,0 +1,68 @@
+#Gamestick bluetooth controller
+
+# Note: The select button which is labelled "back" on the controller needs to 
+# be manually set in retroarch ui as it actually sends a keyboard 
+# "backspace" key code
+
+# you may need to create the following udev rule for this controller to work
+# Create a file named '/etc/udev/rules.d/99-gamestick-controller.rules' with the
+# following line (without the leading # sign):
+
+# SUBSYSTEM=="input", ATTRS{name}=="GameStick Controller", MODE="666", ENV{ID_INPUT_JOYSTICK}="1"
+
+input_driver = "udev"
+input_device = "GameStick Controller"
+
+input_vendor_id = "3853"
+input_product_id = "4113"
+
+input_start_btn = "22"
+input_start_btn_label = "start"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"
+
+input_b_btn = "11"
+input_y_btn = "14"
+input_a_btn = "12"
+input_x_btn = "15"
+input_l_btn = "17"
+input_r_btn = "18"
+input_l2_axis = "+0"
+input_r2_axis = "+1"
+input_l3_btn = "24"
+input_r3_btn = "25"
+
+input_b_btn_label = "A"
+input_y_btn_label = "X"
+input_a_btn_label = "B"
+input_x_btn_label = "Y"
+input_l_btn_label = "LT"
+input_r_btn_label = "RT"
+input_l3_btn_label = "Left Thumb"
+input_r3_btn_label = "Right Thumb"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
+
+input_l_x_plus_axis_label = "Left Analog X+"
+input_l_x_minus_axis_label = "Left Analog X-"
+input_l_y_plus_axis_label = "Left Analog Y+"
+input_l_y_minus_axis_label = "Left Analog Y-"
+input_r_x_plus_axis_label = "Right Analog X+"
+input_r_x_minus_axis_label = "Right Analog X-"
+input_r_y_plus_axis_label = "Right Analog Y+"
+input_r_y_minus_axis_label = "Right Analog Y-"


### PR DESCRIPTION
People might have this controller laying around like me, surprisingly it works good, but no R2/L2 buttons, also the select key is labelled back and sends a keyboard "backspace" so that needs to be mapped manually.  Also attached is the udev rule.  I can create a PR for that as well, but not sure where it goes (had to rename to .txt to attach).

[99-gamestick-controller.rules.txt](https://github.com/libretro/retroarch-joypad-autoconfig/files/2299096/99-gamestick-controller.rules.txt)
