### PR TITLE
Add the 8bitdo SN30 Bluetooth Gamepad (VID 1118 / PID 736)

### DIFF
--- a/xinput/8bitdo_SN30_BT_ALT.cfg
+++ b/xinput/8bitdo_SN30_BT_ALT.cfg
@@ -1,0 +1,38 @@
+# 8Bitdo SN30                 - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30-sf30/
+# Firmware v4.10              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30+SF30/SN30+SF30_Firmware_V4.10.zip
+
+input_driver = "xinput"
+input_device = "XInput Controller (User 1)"
+input_device_display_name = "8Bitdo SN30"
+
+input_vendor_id = "1118"
+input_product_id = "736"
+
+input_b_btn = "0"
+input_y_btn = "2"
+input_select_btn = "7"
+input_start_btn = "6"
+input_a_btn = "1"
+input_x_btn = "3"
+input_l_btn = "4"
+input_r_btn = "5"
+
+input_b_btn_label = "B"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_axis = "+1"
+input_down_axis = "-1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+
+input_up_axis_label = "D-pad Up"
+input_down_axis_label = "D-pad Down"
+input_left_axis_label = "D-pad Left"
+input_right_axis_label = "D-pad Right"
+


### PR DESCRIPTION
I created a profile for the 8Bitdo SN30 Bluetooth Gamepad, which is Vendor 1118 / Product 736, unlike the other profile.  I named it "_ALT".