### PR TITLE
hid: Add 8Bitdo NES30 Pro

### DIFF
--- a/hid/8Bitdo_NES30_Pro.cfg
+++ b/hid/8Bitdo_NES30_Pro.cfg
@@ -1,0 +1,68 @@
+# 8Bitdo NES30 Pro            - http://www.8bitdo.com/     - http://www.8bitdo.com/n30pro-f30pro/
+# Firmware v4.10              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/N30+F30/N30+F30_Firmware_V4.10.zip
+#                             - http://download.8bitdo.com/Manual/Controller/N30+F30/N30+F30_Manual_V4.pdf
+# This is with the device started in Android (D-Input) mode (Power on with no additional buttons)
+
+input_driver = "hid"
+input_device = "8Bitdo NES30 Pro"
+input_vendor_id = "11720"
+input_product_id = "14368"
+
+input_a_btn = "0"
+input_b_btn = "1"
+input_x_btn = "3"
+input_y_btn = "4"
+
+input_select_btn = "10"
+input_start_btn = "11"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_l_btn = "6"
+input_r_btn = "7"
+input_l2_btn = "8"
+input_r2_btn = "9"
+input_l3_btn = "13"
+input_r3_btn = "14"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+4"
+input_r_x_minus_axis = "-4"
+input_r_y_plus_axis = "+5"
+input_r_y_minus_axis = "-5"
+
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+
+input_a_btn_label = "A"
+input_b_btn_label = "B"
+input_x_btn_label = "X"
+input_y_btn_label = "Y"
+
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "L2"
+input_r2_btn_label = "R2"
+input_l3_btn_label = "LS"
+input_r3_btn_label = "RS"
+
+input_up_btn_label = "D-pad Up"
+input_down_btn_label = "D-pad Down"
+input_left_btn_label = "D-pad Left"
+input_right_btn_label = "D-pad Right"
+
+input_l_x_plus_axis_label = "LS Right"
+input_l_x_minus_axis_label = "LS Left"
+input_l_y_plus_axis_label = "LS Down"
+input_l_y_minus_axis_label = "LS Up"
+
+input_r_x_plus_axis_label = "RS Right"
+input_r_x_minus_axis_label = "RS Left"
+input_r_y_plus_axis_label = "RS Down"
+input_r_y_minus_axis_label = "RS Up"


### PR DESCRIPTION
Add support for 8Bitdo NES30 Pro. 

Notes:

* This is for the Android mode where you power on with no additional buttons pressed. It shows up as "8Bitdo NES30 Pro" this way.
* Works for both BT and USB
* Tested on the latest firmware as of now (4.10) as well as 4.01
* You can also start it up in macOS mode by holding A during power on, but then it spoofs as a DS4 controller and this config won't apply
  * If you run it in this mode it makes RA segafult when exiting so I recommend running it in the default (Android) mode