### PR TITLE
hid: Add 8Bitdo SNES30

### DIFF
--- a/hid/8Bitdo_SNES30_BT.cfg
+++ b/hid/8Bitdo_SNES30_BT.cfg
@@ -1,0 +1,41 @@
+# 8Bitdo SNES30               - http://www.8bitdo.com/
+# Firmware v4.10              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30+SF30/SN30+SF30_Firmware_V4.10.zip
+#                             - http://download.8bitdo.com/Manual/Controller/SN30+SF30/SN30+SF30_Manual_V4.pdf
+# This is with the device started in Android (D-Input) mode (Power on with no additional buttons)
+
+input_driver = "hid"
+input_device = "8Bitdo SNES30 GamePad"
+input_vendor_id = "11720"
+input_product_id = "10304"
+
+input_a_btn = "0"
+input_b_btn = "1"
+input_x_btn = "3"
+input_y_btn = "4"
+
+input_select_btn = "10"
+input_start_btn = "11"
+
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+
+input_l_btn = "6"
+input_r_btn = "7"
+
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+
+input_a_btn_label = "A"
+input_b_btn_label = "B"
+input_x_btn_label = "X"
+input_y_btn_label = "Y"
+
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_btn_label = "D-pad Up"
+input_down_btn_label = "D-pad Down"
+input_left_btn_label = "D-pad Left"
+input_right_btn_label = "D-pad Right"

--- a/hid/8Bitdo_SNES30_USB.cfg
+++ b/hid/8Bitdo_SNES30_USB.cfg
@@ -1,0 +1,41 @@
+# 8Bitdo SNES30               - http://www.8bitdo.com/
+# Firmware v4.10              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30+SF30/SN30+SF30_Firmware_V4.10.zip
+#                             - http://download.8bitdo.com/Manual/Controller/SN30+SF30/SN30+SF30_Manual_V4.pdf
+# This is with the device connected via USB
+
+input_driver = "hid"
+input_device = "SNES30 Joy   "
+input_vendor_id = "11720"
+input_product_id = "43808"
+
+input_a_btn = "0"
+input_b_btn = "1"
+input_x_btn = "3"
+input_y_btn = "4"
+
+input_select_btn = "10"
+input_start_btn = "11"
+
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+
+input_l_btn = "6"
+input_r_btn = "7"
+
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+
+input_a_btn_label = "A"
+input_b_btn_label = "B"
+input_x_btn_label = "X"
+input_y_btn_label = "Y"
+
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_btn_label = "D-pad Up"
+input_down_btn_label = "D-pad Down"
+input_left_btn_label = "D-pad Left"
+input_right_btn_label = "D-pad Right"


### PR DESCRIPTION
Add support for 8Bitdo SNES30.

Notes:

* This is for the Android mode where you power on with no additional buttons pressed. It shows up as "8Bitdo SNES30 GamePad" this way.
* In USB it shows up as "SNES30 Joy   "
* Separate configs for BT and USB because the pid differs for each (same vid)
* Tested on the latest firmware as of now (4.10)
* Not sure if it makes a difference, but this was tested on a model prior to the rebranding to SN30