### PR TITLE
Update 8Bitdo_N30_Modkit_BT.cfg

### DIFF
--- a/android/8Bitdo_N30_Modkit_BT.cfg
+++ b/android/8Bitdo_N30_Modkit_BT.cfg
@@ -1,14 +1,12 @@
 # 8Bitdo N30 Modkit           - http://www.8bitdo.com/     - http://www.8bitdo.com/mod-kit-for-nes-controller/
-# Firmware v5.08              - http://support.8bitdo.com/ 
+# Firmware v6.10              - http://support.8bitdo.com/ 
 
-input_driver = "xinput"
+input_driver = "android"
 input_device = "8Bitdo N30 Modkit"
 input_device_display_name = "8Bitdo N30 Modkit"
 
-# Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retroarch.cfg and run RetroArch.
-# Hex vid:pid = 045E:02E0 -> Decimal vid:pid = 1118:736
-input_vendor_id = "1118"
-input_product_id = "736"
+input_vendor_id = "11720"
+input_product_id = "20740"
 
 input_b_btn = "97"
 input_select_btn = "109"
@@ -20,8 +18,8 @@ input_select_btn_label = "Select"
 input_start_btn_label = "Start"
 input_a_btn_label = "A"
 
-input_up_axis = "+1"
-input_down_axis = "-1"
+input_up_axis = "-1"
+input_down_axis = "+1"
 input_left_axis = "-0"
 input_right_axis = "+0"
 


### PR DESCRIPTION
Received a new 8Bitdo N30 Modkit (NES Classic Controller Version) with the latest firmware (v6.10) and it didn't work out of the box with retroarch's autoconfig. I had to create a new autoconfig file to work with the updated firmware. Both the VID and PID changed. The up/down axis values also had to be inverted. The new changes work with the latest current firmware and were tested with the android version of retroarch on the Shield TV.