### PR TITLE
Update 8Bitdo_M30_BT.cfg

### DIFF
--- a/android/8Bitdo_M30_BT.cfg
+++ b/android/8Bitdo_M30_BT.cfg
@@ -1,5 +1,5 @@
 # 8Bitdo M30                  - http://www.8bitdo.com/     - http://www.8bitdo.com/m30/
-# Firmware v1.00              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/M30/M30_Firmware_V1.00.zip
+# Firmware v1.13              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/M30/M30_Firmware_V1.13.zip
 
 input_driver = "android"
 input_device = "8Bitdo M30 GamePad"
@@ -39,3 +39,13 @@ input_up_axis_label = "D-pad Up"
 input_down_axis_label = "D-pad Down"
 input_left_axis_label = "D-pad Left"
 input_right_axis_label = "D-pad Right"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"


### PR DESCRIPTION
Firmware 1.10 introduces switching between d-pad and joystick mode for left thumbstick as seen in the update log
http://support.8bitdo.com/#data_history_m30

No change to button labels or assignments.