### PR TITLE
Updated Retro-Bit Tribute64 - USB (D-Input).cfg

### DIFF
--- a/xinput/Retro-Bit Tribute64 - USB (D-Input).cfg
+++ b/xinput/Retro-Bit Tribute64 - USB (D-Input).cfg
@@ -4,8 +4,8 @@
 input_driver = "xinput"
 input_device = "Controller (Dinput)"
 input_device_display_name = "Retro-Bit Tribute64 - USB (D-Input)"
-input_vendor_id = "1118"
-input_product_id = "654"
+input_vendor_id = "045E"
+input_product_id = "028E"
 
 input_b_btn = "1"
 input_a_btn = "2"


### PR DESCRIPTION
Updated input_vendor_id and input_product_id for Retro-Bit Tribute64 - USB (D-Input)

I've now taken the vid/pid from Windows device manager rather than the auto-generated RetroArch values.

Tested and fully working in Mupen64Plus-Next, hopefully, these are the correct and unique device values.