### PR TITLE
Add Retrode files for Linux

### DIFF
--- a/udev/Retrode Mega Drive _1.cfg
+++ b/udev/Retrode Mega Drive _1.cfg
@@ -1,0 +1,33 @@
+#
+# Retrode 2 USB adapter for original SNES and MegaDrive/Genesis gamepads - https://www.retrode.org
+#
+input_driver = "udev"
+input_device = "Retrode Mega Drive #1"
+input_vendor_id = "1027"
+input_product_id = "38849"
+input_b_btn = "0"
+input_y_btn = "1"
+input_select_btn = "2"
+input_start_btn = "3"
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_a_btn = "4"
+input_x_btn = "5"
+input_l_btn = "6"
+input_r_btn = "7"
+
+input_b_btn_label = "B"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_axis_label = "Dpad Up"
+input_down_axis_label = "Dpad Down"
+input_left_axis_label = "Dpad Left"
+input_right_axis_label = "Dpad Right"

--- a/udev/Retrode Mega Drive _2.cfg
+++ b/udev/Retrode Mega Drive _2.cfg
@@ -1,0 +1,33 @@
+#
+# Retrode 2 USB adapter for original SNES and MegaDrive/Genesis gamepads - https://www.retrode.org
+#
+input_driver = "udev"
+input_device = "Retrode Mega Drive #2"
+input_vendor_id = "1027"
+input_product_id = "38849"
+input_b_btn = "0"
+input_y_btn = "1"
+input_select_btn = "2"
+input_start_btn = "3"
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_a_btn = "4"
+input_x_btn = "5"
+input_l_btn = "6"
+input_r_btn = "7"
+
+input_b_btn_label = "B"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_axis_label = "Dpad Up"
+input_down_axis_label = "Dpad Down"
+input_left_axis_label = "Dpad Left"
+input_right_axis_label = "Dpad Right"

--- a/udev/Retrode SNES _ N64 _1.cfg
+++ b/udev/Retrode SNES _ N64 _1.cfg
@@ -1,0 +1,33 @@
+#
+# Retrode 2 USB adapter for original SNES and MegaDrive/Genesis gamepads - https://www.retrode.org
+#
+input_driver = "udev"
+input_device = "Retrode SNES / N64 #1"
+input_vendor_id = "1027"
+input_product_id = "38849"
+input_b_btn = "0"
+input_y_btn = "1"
+input_select_btn = "2"
+input_start_btn = "3"
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_a_btn = "4"
+input_x_btn = "5"
+input_l_btn = "6"
+input_r_btn = "7"
+
+input_b_btn_label = "B"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_axis_label = "Dpad Up"
+input_down_axis_label = "Dpad Down"
+input_left_axis_label = "Dpad Left"
+input_right_axis_label = "Dpad Right"

--- a/udev/Retrode SNES _ N64 _2.cfg
+++ b/udev/Retrode SNES _ N64 _2.cfg
@@ -1,0 +1,33 @@
+#
+# Retrode 2 USB adapter for original SNES and MegaDrive/Genesis gamepads - https://www.retrode.org
+#
+input_driver = "udev"
+input_device = "Retrode SNES / N64 #2"
+input_vendor_id = "1027"
+input_product_id = "38849"
+input_b_btn = "0"
+input_y_btn = "1"
+input_select_btn = "2"
+input_start_btn = "3"
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_a_btn = "4"
+input_x_btn = "5"
+input_l_btn = "6"
+input_r_btn = "7"
+
+input_b_btn_label = "B"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_axis_label = "Dpad Up"
+input_down_axis_label = "Dpad Down"
+input_left_axis_label = "Dpad Left"
+input_right_axis_label = "Dpad Right"

--- a/xinput/Retrode_2.cfg
+++ b/xinput/Retrode_2.cfg
@@ -1,3 +1,6 @@
+#
+# Retrode 2 USB adapter for original SNES and MegaDrive/Genesis gamepads - https://www.retrode.org
+#
 input_driver = "xinput"
 input_device = "Retrode"
 input_vendor_id = "1027"


### PR DESCRIPTION
I saved the autoconfig files on Linux, so the `input_device` names were automatically detected.
Then added labels.