### PR TITLE
Disable conflicting (duplicated) profiles

### DIFF
--- a/android/Defender_Game_Racer_Classic.cfg
+++ b/android/Defender_Game_Racer_Classic.cfg
@@ -1,7 +1,14 @@
 # Verify if D-pad works with hat controls
 
-input_device = "USB Gamepad"
 input_driver = "android"
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: Trust_Predator.cfg
+#input_device = "USB Gamepad"
+
 input_b_btn = "188"
 input_y_btn = "191"
 input_select_btn = "196"

--- a/android/GPD_Q9.cfg
+++ b/android/GPD_Q9.cfg
@@ -1,7 +1,13 @@
 # Verify if analog right works properly
-
-input_device = "PlayStation3"
 input_driver = "android"
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: DualShock3.cfg
+#input_device = "PlayStation3"
+
 input_b_btn = "97"
 input_y_btn = "100"
 input_select_btn = "109"

--- a/dinput/DragonRise_Inc.___Generic___USB__Joystick__.cfg
+++ b/dinput/DragonRise_Inc.___Generic___USB__Joystick__.cfg
@@ -1,9 +1,15 @@
 input_driver = "dinput"
-input_device = "Generic   USB  Joystick  "
-input_device_display_name = "DragonRise zero delay encoder"
 
-input_vendor_id = "121"
-input_product_id = "6"
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: Retrolink_N64_USB.cfg
+#input_vendor_id = "121"
+#input_product_id = "6"
+#input_device = "Generic   USB  Joystick  "
+
+input_device_display_name = "DragonRise zero delay encoder"
 
 input_x_btn = "0"
 input_a_btn = "1"

--- a/udev/DIALOG_GP-A11.cfg
+++ b/udev/DIALOG_GP-A11.cfg
@@ -3,10 +3,18 @@
 #
 input_device_display_name = "Dialog GP-A11"
 #
-input_device = "DragonRise Inc.   Generic   USB  Joystick  "
+
 input_driver = "udev"
-input_vendor_id = "121"
-input_product_id = "6"
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: DragonRise_N64.cfg
+#input_device = "DragonRise Inc.   Generic   USB  Joystick  "
+#input_vendor_id = "121"
+#input_product_id = "6"
+
 ##
 input_select_btn = "8"
 input_start_btn = "9"

--- a/udev/DragonRise Inc. Gamepad.cfg
+++ b/udev/DragonRise Inc. Gamepad.cfg
@@ -11,9 +11,16 @@
 # 1 2 3 4 L R L2 R2 Se St
 
 input_driver = "udev"
-input_vendor_id = 121
-input_product_id = 17
-input_device = "USB Gamepad "
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: Retrolink_Sega_Saturn_USB_GamePad.cfg
+#input_vendor_id = 121
+#input_product_id = 17
+#input_device = "USB Gamepad "
+
 input_device_display_name = "DragonRise generic PlayStation gamepad"
 
 #########

--- a/udev/DragonRise_Inc.___Generic___USB__Joystick__.cfg
+++ b/udev/DragonRise_Inc.___Generic___USB__Joystick__.cfg
@@ -1,7 +1,14 @@
 input_driver = "udev"
-input_vendor_id = 121
-input_product_id = 6
-input_device = "DragonRise Inc.   Generic   USB  Joystick  "
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: DragonRise_N64.cfg
+#input_vendor_id = 121
+#input_product_id = 6
+#input_device = "DragonRise Inc.   Generic   USB  Joystick  "
+
 input_device_display_name = "DragonRise zero delay encoder"
 
 input_x_btn = "0"

--- a/udev/DragonRise_X-Box_Gamepad_with_Force_Feedback.cfg
+++ b/udev/DragonRise_X-Box_Gamepad_with_Force_Feedback.cfg
@@ -16,10 +16,17 @@
 # Therefore removed axis 2 from the config.
 
 input_driver = "udev"
-input_device = "DragonRise Inc.   Generic   USB  Joystick  "
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: DragonRise_N64.cfg
+#input_device = "DragonRise Inc.   Generic   USB  Joystick  "
+#input_vendor_id = "121"
+#input_product_id = "6"
+
 input_device_display_name = "DragonRise X-Box Gamepad with Force Feedback"
-input_vendor_id = "121"
-input_product_id = "6"
 
 input_up_btn = "h0up"
 input_down_btn = "h0down"

--- a/udev/Gametel_Bluetooth_controller.cfg
+++ b/udev/Gametel_Bluetooth_controller.cfg
@@ -1,12 +1,19 @@
 input_driver = "udev"
-input_device = "Gametel"
-input_device_display_name = "Gametel Bluetooth controller"
+
 #On Linux - if this Bluetooth controller is not recognized by the system then create a file "99-gametel.rules" with following content:
 #SUBSYSTEM=="input", ATTRS{name}=="Gametel", KERNEL=="event*", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
 #and copy this file to following location: /etc/udev/rules.d/
 
-input_vendor_id = "9654"
-input_product_id = "1"
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: Gametel.cfg
+#input_device = "Gametel"
+#input_vendor_id = "9654"
+#input_product_id = "1"
+
+input_device_display_name = "Gametel Bluetooth controller"
 
 input_a_btn = "4"
 input_b_btn = "7"

--- a/udev/HuiJia  USB GamePad.cfg
+++ b/udev/HuiJia  USB GamePad.cfg
@@ -1,7 +1,14 @@
 input_driver = "udev"
-input_device = "HuiJia  USB GamePad"
-input_vendor_id = "3727"
-input_product_id = "12307"
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: Mayflash_N64_to_USB_Adapter.cfg
+#input_device = "HuiJia  USB GamePad"
+#input_vendor_id = "3727"
+#input_product_id = "12307"
+
 input_b_btn = "2"
 input_y_btn = "3"
 input_select_btn = "8"

--- a/udev/USB_Gamepad_.cfg
+++ b/udev/USB_Gamepad_.cfg
@@ -1,7 +1,14 @@
-input_device = "USB Gamepad "
 input_driver = "udev"
-input_vendor_id = 121
-input_product_id = 17
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: Retrolink_Sega_Saturn_USB_GamePad.cfg
+#input_device = "USB Gamepad "
+#input_vendor_id = 121
+#input_product_id = 17
+
 input_b_btn = "2"
 input_y_btn = "3"
 input_select_btn = "8"

--- a/udev/usb_gamepad___________(NES).cfg
+++ b/udev/usb_gamepad___________(NES).cfg
@@ -4,9 +4,15 @@
 # chip common in other gamepads with different button configurations.
 
 input_driver = "udev"
-input_device = "usb gamepad           "
-input_vendor_id = "2064"
-input_product_id = "58625"
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: usb_gamepad___________(PS1).cfg
+#input_device = "usb gamepad           "
+#input_vendor_id = "2064"
+#input_product_id = "58625"
 
 #########
 

--- a/udev/usb_gamepad___________(SEGA).cfg
+++ b/udev/usb_gamepad___________(SEGA).cfg
@@ -10,10 +10,18 @@
 #
 input_device_display_name = "SEGA - style usb gamepad"
 #
+
 input_driver = "udev"
-input_device = "usb gamepad           "
-input_vendor_id = "2064"
-input_product_id = "58625"
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: usb_gamepad___________(PS1).cfg
+#input_device = "usb gamepad           "
+#input_vendor_id = "2064"
+#input_product_id = "58625"
+
 ##
 # NO MODE BTN
 #input_select_btn = ""

--- a/udev/usb_gamepad___________(SNES).cfg
+++ b/udev/usb_gamepad___________(SNES).cfg
@@ -4,9 +4,15 @@
 # chip common in other gamepads with different button configurations.
 
 input_driver = "udev"
-input_device = "usb gamepad           "
-input_vendor_id = "2064"
-input_product_id = "58625"
+
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: usb_gamepad___________(PS1).cfg
+#input_device = "usb gamepad           "
+#input_vendor_id = "2064"
+#input_product_id = "58625"
 
 #########
 

--- a/xinput/DragonRise_Inc.___Generic___USB__Joystick__.cfg
+++ b/xinput/DragonRise_Inc.___Generic___USB__Joystick__.cfg
@@ -1,9 +1,15 @@
 input_driver = "xinput"
-input_device = "Generic   USB  Joystick  "
-input_device_display_name = "DragonRise zero delay encoder"
 
-input_vendor_id = "121"
-input_product_id = "6"
+# Currently Retroarch can't differentiate between input devices
+# sharing the same input_vendor_id, input_product_id, and
+# input_device. We decided to disable the duplicates until 
+# Retroarch implements a feature to disambiguate between them.
+# This file was commented in favor of: Retrolink_N64_USB.cfg
+#input_vendor_id = "121"
+#input_product_id = "6"
+#input_device = "Generic   USB  Joystick  "
+
+input_device_display_name = "DragonRise zero delay encoder"
 
 input_x_btn = "0"
 input_a_btn = "1"


### PR DESCRIPTION
As we discussed in #424 we need to clean up duplicated/conflicting profiles from the repo. 

The problem with duplicated profiles is that Retroarch isn't capable of disambiguating between them, so it will choose one or the other just by chance.  

The goal of this PR is to keep just one set of the duplicated profiles enabled, commenting `input_device`, `input_vendor_id`, and `input_product_id` lines to disable those profiles.

cc @hizzlekizzle 