### PR TITLE
Add automatic check for duplicate profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 2.5.3
+script: ruby verify_duplicate_profiles.rb

--- a/verify_duplicate_profiles.rb
+++ b/verify_duplicate_profiles.rb
@@ -1,0 +1,93 @@
+require 'pathname'
+
+class InputDevice
+  attr_reader :filename, :input_device, :input_vendor_id, :input_product_id
+
+  def initialize(filename:, input_device:, input_vendor_id:, input_product_id:)
+    @filename = filename
+    @input_device = input_device
+    @input_vendor_id = input_vendor_id
+    @input_product_id = input_product_id
+  end
+
+  def self.from_file(file)
+    parsed_file = Hash[file.read.scan(/^([^#\s]+)\s*=\s*"?([^"\n]+)"?/)]
+
+    new(
+      filename: file.to_s,
+      input_device: parsed_file['input_device'],
+      input_vendor_id: parsed_file['input_vendor_id'],
+      input_product_id: parsed_file['input_product_id'],
+    )
+  end
+
+  def unique_identifier
+    [input_vendor_id, input_product_id, input_device].join("-")
+  end
+
+  def disabled?
+    input_vendor_id.nil? && input_product_id.nil? && input_device.nil?
+  end
+
+  def report_attributes
+    [
+      "Vendor ID: #{report_value(input_vendor_id)}",
+      "Product ID: #{report_value(input_product_id)}",
+      "Name: #{report_value(input_device)}"
+    ].join(" - ")
+  end
+
+  def report_value(value)
+    value || "empty"
+  end
+end
+
+def input_devices_from(files)
+  files.map { |f| InputDevice.from_file(f) }.reject(&:disabled?)
+end
+
+def config_files_per_driver
+  Pathname.glob('*/*.cfg').group_by(&:parent)
+end
+
+def find_duplicates
+  config_files_per_driver.each_with_object(Hash.new) do |(driver, cfg_files), duplicates|
+    duplicate_devices = input_devices_from(cfg_files).
+                        group_by(&:unique_identifier).
+                        select { |id, devices| devices.size > 1 }
+
+    duplicates[driver.to_s] = duplicate_devices unless duplicate_devices.empty?
+  end
+end
+
+def colorize(text, color_code)
+  "#{color_code}#{text}\e[0m"
+end
+
+def green(text); colorize(text, "\e[32m"); end
+def red(text); colorize(text, "\e[31m"); end
+def yellow(text); colorize(text, "\e[33m"); end
+
+
+def report_duplicates(duplicates_per_driver)
+  puts red("Some duplicate profiles were found")
+  duplicates_per_driver.each do |driver_name, duplicates|
+    puts green("Duplicates inside '#{driver_name}'")
+
+    duplicates.each do |group_id, devices|
+      puts yellow(devices.first.report_attributes)
+      devices.each { |d| puts "- #{d.filename}" }
+      puts "\n"
+    end
+  end
+end
+
+duplicates = find_duplicates
+
+if duplicates.empty?
+  puts green("No duplicate profiles were found")
+  exit 0
+else
+  report_duplicates(duplicates)
+  exit 1
+end


### PR DESCRIPTION
I've been working on a script to automatically detect duplicate profiles when somebody creates a Pull Request. The goal behind this is to avoid future conflicts without having to ask reviewers to manually scan all the profiles in the repository to confirm there aren't duplicates present.

This PR includes:
- Ruby script that scans the whole repository looking for duplicates
- [Travis CI](https://travis-ci.com/) configuration

Travis CI is a cloud-based continuous integration tool that can be used to automatically build software projects. They provide a free plan for open-source projects, so we can take advantage of that at no cost.

They provide a "GitHub App" integration that is really easy to setup. I don't have permissions to set up the integration in this repo so that must be performed by Retroarch's team. 

You can see how the integration works in my fork: https://github.com/MatiasFernandez/retroarch-joypad-autoconfig/pull/1/checks?check_run_id=228314411

Here is a list of runs, some failing (while I was testing with duplicate profiles) and at the end one that is "green" that means no duplicates were found (the current state of this repo): https://travis-ci.com/MatiasFernandez/retroarch-joypad-autoconfig/builds

The Travis Setup is mostly plug-and-play (now that I'm adding the config file to the repo). But I can help you to set it up if you want. On Github side, I suggest enabling branch protection over `master` requiring the step "Travis CI - Pull Request". That ensures that a new Pull Request created from a forked repository won't be merged if there are duplicates around.

i.e:

![image](https://user-images.githubusercontent.com/7898112/65243446-c1b4be00-dabe-11e9-9fcc-c3537e3d9d14.png)


These are some screenshots of the integration working:

![image](https://user-images.githubusercontent.com/7898112/65243079-00964400-dabe-11e9-9d1a-604b31fe653b.png)

![image](https://user-images.githubusercontent.com/7898112/65243118-1572d780-dabe-11e9-8e59-4ba564fcbddd.png)

![image](https://user-images.githubusercontent.com/7898112/65243177-35a29680-dabe-11e9-9a1f-91870508b49a.png)

![image](https://user-images.githubusercontent.com/7898112/65243232-55d25580-dabe-11e9-8c2c-369a0a12e490.png)
