### PR TITLE
Fix stick axis in dinput SQONYY_gamepad.cfg

### DIFF
--- a/dinput/SQONYY_gamepad.cfg
+++ b/dinput/SQONYY_gamepad.cfg
@@ -1,4 +1,4 @@
-Configuration with analog mode enabled (red led switched on)
+#Configuration with analog mode enabled (red led switched on)
 
 input_driver = "dinput"
 input_device = "USB Joystick          "
@@ -23,7 +23,7 @@ input_l3_btn = "10"
 input_r3_btn = "11"
 input_l_x_plus_axis = "+0"
 input_l_x_minus_axis = "-0"
-input_l_y_plus_axis = "-0"
+input_l_y_plus_axis = "+1"
 input_l_y_minus_axis = "-1"
 input_r_x_plus_axis = "+2"
 input_r_x_minus_axis = "-2"


### PR DESCRIPTION
Apparently the current state causes up to be pressed continuously. Fix has been verified by Zaion on the retroachievements discord.