### PR TITLE
Update and rename Moonlight_Virtual_Controller.cfg to NVIDIA_GeForce_…

### DIFF
--- a/xinput/NVIDIA_GeForce_Experience_Virtual_Controller.cfg
+++ b/xinput/NVIDIA_GeForce_Experience_Virtual_Controller.cfg
@@ -1,6 +1,6 @@
 input_driver = "xinput"
-input_device = "Moonlight Virtual Controller"
-input_device_display_name = "Moonlight Virtual Controller"
+input_device = "NVIDIA GeForce Experience Virtual Controller"
+input_device_display_name = "NVIDIA GeForce Experience Virtual Controller"
 
 #this pad has the same IDs as Nvidia Shield controller
 #input_vendor_id = "2389"


### PR DESCRIPTION
This is a virtual controller passed to the PC when using Moonlight app and NVIDIA GameStream/GeForce Experience. The app developers say the VID/PID is controlled by GeForce Experience and they cannot control it (https://github.com/moonlight-stream/moonlight-android/issues/818), although I did not have mapping problems when using GameStream on Nvidia Shield instead of the Moonlight app. Anyway the same VID/PID is used as the Nvidia Shield controller.

For my testing I was using an Xbox One bluetooth controller connected to Nvidia Shield TV using the Moonlight app. When using this auto config file everything mapped correctly.