### PR TITLE
Remove (wired) appendix from profile name

### DIFF
--- a/android/Sony Interactive Entertainment Wireless Controller.cfg
+++ b/android/Sony Interactive Entertainment Wireless Controller.cfg
@@ -1,6 +1,6 @@
 input_driver = "android"
 input_device = "Sony Interactive Entertainment Wireless Controller"
-input_device_display_name = "Dualshock 4 V2 Controller (Wired)"
+input_device_display_name = "Dualshock 4 V2 Controller"
 input_vendor_id = "1356"
 input_product_id = "2508"
 input_b_btn = "96"


### PR DESCRIPTION
The profile is used by both wired and wireless Dualshock 4 V2's