### PR TITLE
Add d-pad up to the Google Nexus Gamepad config

### DIFF
--- a/android/Google_Nexus_Controller.cfg
+++ b/android/Google_Nexus_Controller.cfg
@@ -4,6 +4,7 @@ input_driver = "android"
 input_vendor_id = "6353"
 input_product_id = "11328"
 
+input_up_btn = "h0up"
 input_down_btn = "h0down"
 input_left_btn = "h0left"
 input_right_btn = "h0right"


### PR DESCRIPTION
D-pad up is missing when I use my Nexus Gamepad, and this looks like why. It's untested, as I don't know how to test a gamepad config in unrooted Android without getting a whole build environment up, but this change looks like it can't cause harm, and the current config is definitely broken.