### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 PREFIX := /usr
 INSTALLDIR := $(PREFIX)/share/libretro/autoconfig
+DOC_DIR := $(PREFIX)/share/doc/retroarch-joypad-autoconfig
 
 all:
 	@echo "Nothing to make for retroarch-joypad-autoconfig."
 
 install:
-	mkdir -p $(DESTDIR)$(INSTALLDIR)
-	cp -ar * $(DESTDIR)$(INSTALLDIR)
-	rm -rf $(DESTDIR)$(INSTALLDIR)/Makefile \
-		$(DESTDIR)$(INSTALLDIR)/configure
+	for driver in android dinput hid linuxraw parport qnx sdl2 udev x xinput; do \
+		install -Dm644 -t $(DESTDIR)$(INSTALLDIR)/$$driver $$driver/*.cfg; \
+	done
+	install -Dm644 -t $(DESTDIR)$(DOC_DIR) COPYING README.md retropad_layout.png
 
 test-install: all
 	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
This will help package maintainers efforts by only copying useful files, in the right directories. This will also fix permissions because multiple *.cfg files have executable permission set.