### PR TITLE
Added NVIDIA SHIELD 2019 Remote

### DIFF
--- a/android/NVIDIA_SHIELD_2019_Remote.cfg
+++ b/android/NVIDIA_SHIELD_2019_Remote.cfg
@@ -1,0 +1,31 @@
+# This controller is intended for menu navigation only
+# it will work fine with an upcoming version that will bind remotes
+# and other general purpose I/O devices to a dedicated input port
+
+input_device = "SHIELD 2019 Remote"
+input_device_display_name = "NVIDIA SHIELD 2019 Remote"
+input_driver = "android"
+input_device_type = "remote"
+
+input_vendor_id = "2389"
+input_product_id = "29207"
+
+input_b_btn = "4"
+input_select_btn = "90"
+input_start_btn = "85"
+input_up_btn = "19"
+input_down_btn = "20"
+input_left_btn = "21"
+input_right_btn = "22"
+input_a_btn = "23"
+input_menu_toggle_btn = "89"
+
+input_b_btn_label = "Back"
+input_select_btn_label = "Fast Forward"
+input_start_btn_label = "Play/Pause"
+input_up_btn_label = "Up"
+input_down_btn_label = "Down"
+input_left_btn_label = "Left"
+input_right_btn_label = "Right"
+input_a_btn_label = "Center"
+input_menu_toggle_btn_label = "Rewind"


### PR DESCRIPTION
This PR adds a profile for the NVIDIA SHIELD 2019 Remote, which comes with the NVIDIA SHIELD 2019 Pro and the regular "tube" version. The remote can be purchased separatedly as well.

Because it's a TV-like remote, the mappings are a bit limited but fully functional to navigate the RetroArch interface and use in cores with at most two buttons, e.g. NES or MegaDrive:

| Remote Button | RetroPad Button |
|:--|:--|
| Center | A button |
| Back | B button |
| Play/Pause | Start button |
| Fast Forward | Select button |
| Up | D-Pad Up |
| Down | D-Pad Down |
| Left | D-Pad Left |
| Right | D-Pad Right |
| Rewind | Menu toggle button |

> **Note:** Buttons in the remote that are not in the above table are not assignable, e.g. Mic, Home, Volume Up/Down, etc. :(

Tested on real hardware.

![image](https://user-images.githubusercontent.com/5802993/87080027-e1b89800-c21e-11ea-9fa8-980044b26c43.png)
