### PR TITLE
Add Quasicon 2P Arcade Control (udev)

### DIFF
--- a/udev/Honey Bee QuasiCON.cfg
+++ b/udev/Honey Bee QuasiCON.cfg
@@ -1,0 +1,80 @@
+# QuasiCON 2P Control Panel
+# Arcade Control Panel
+# Button Layout Image: http://file.bodnara.co.kr/logo/insidelogo.php?image=%2Fhttp%3A%2F%2Ffile.bodnara.co.kr%2Fwebedit%2Fnews%2F2005%2F1145581286-fx4.jpg
+
+#Controller Setup
+input_driver = "udev"
+input_device = "Honey Bee QuasiCON"
+input_device_display_name = "QuasiCON 2P"
+
+# Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
+# Hex vid:pid = 2717:3144 -> Decimal vid:pid = 10007:12612
+input_vendor_id = "4779"
+input_product_id = "2"
+
+#Joystick Mappings
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_up_btn_label = "Joy Up"
+input_down_btn_label = "Joy Down"
+input_left_btn_label = "Joy Left"
+input_right_btn_label = "Joy Right"
+
+#Button Mappings
+input_a_btn = "1"
+input_b_btn = "0"
+input_x_btn = "3"
+input_y_btn = "2"
+
+input_a_btn_label = "Bottom Right Button 2 (PC)"
+input_b_btn_label = "Bottom Center Button 1 (PC)"
+input_x_btn_label = "Top Right Button 4 (PC)"
+input_y_btn_label = "Top Center Button 3 (PC)"
+
+#L and R Shoulder Buttons
+input_l_btn = "7"
+input_r_btn = "6"
+
+input_l_btn_label = "Top Left Button 8 (PC)"
+input_r_btn_label = "Bottom Right Button 7 (PC)"
+
+#L2 and R2 triggers
+input_l2_btn = "8"
+input_r2_btn = "9"
+
+input_l2_btn_label = "Left Bottom Button 9 (PC)"
+input_r2_btn_label = "Right Bottom Button 10 (PC)"
+
+# Start and Select Button
+input_start_btn = "5"
+input_select_btn = "4"
+input_menu_toggle_btn = "8"
+
+input_start_btn_label = "Left Top Button 6 (PC)"
+input_select_btn_label = "Left Center Button 5 (PC)"
+input_menu_toggle_btn_label = "Left Bottom Button 9 (PC)"
+
+# Left Analog Stick
+input_l_x_minus_axis = "-0"
+input_l_x_plus_axis = "+0"
+input_l_y_minus_axis = "-1"
+input_l_y_plus_axis = "+1"
+
+input_l_x_plus_axis_label = "Left Analog (Right)"
+input_l_x_minus_axis_label = "Left Analog (Left)"
+input_l_y_plus_axis_label = "Left Analog (Up)"
+input_l_y_minus_axis_label = "Left Analog (Down)"
+
+# Right Analog Stick
+input_r_x_minus_axis = "-3"
+input_r_x_plus_axis = "+3"
+input_r_y_minus_axis = "-2"
+input_r_y_plus_axis = "+2"
+
+input_r_x_plus_axis_label = "Right Analog (Right)"
+input_r_x_minus_axis_label = "Right Analog (Left)"
+input_r_y_plus_axis_label = "Right Analog (Up)"
+input_r_y_minus_axis_label = "Right Analog (Down)"


### PR DESCRIPTION
Added autoconfig file for Quasicon 2P Arcade Controller (udev)

- default setup for all buttons
- labels for buttons and axis

![afdea5c426de41ac8d2faeca88d6191b](https://user-images.githubusercontent.com/47097855/87218818-1144ce80-c30b-11ea-89f8-a0cc389ed7f6.jpg)
