### PR TITLE
Add Qanba Q4RAF arcade stick

### DIFF
--- a/udev/QanBa_Q4RAF_Arcade_Stick.cfg
+++ b/udev/QanBa_Q4RAF_Arcade_Stick.cfg
@@ -1,0 +1,72 @@
+# Jess Technology Co., Ltd
+# QanBa Q4RAF Arcade Stick
+# Decimal vid:pid = 3888:4111
+# Hex vid:pid = 0f30:1012
+
+# PS3/PC mode
+
+# | Q4 Label | Button  | Retropad |
+# | A        | 0       | B        |
+# | B        | 1       | A        |
+# | X        | 2       | Y        |
+# | Y        | 3       | X        |
+# | R1       | 4       | L1       |
+# | R2       | 6       | R1       |
+# | L1       | 5       | L2       |
+# | L2       | 7       | R2       |
+# | Select   | 8       | Select   |
+# | Start    | 9       | Start    |
+
+input_driver = "udev"
+input_device = "Jess Technology Co., Ltd. QanBa Joystick Plus"
+input_device_display_name = "QanBa Q4RAF Arcade Stick"
+
+input_vendor_id = "3888"
+input_product_id = "4114"
+
+input_a_btn = "1"
+input_b_btn = "0"
+input_y_btn = "2"
+input_x_btn = "3"
+input_l_btn = "4"
+input_r_btn = "6"
+input_l2_btn = "5"
+input_r2_btn = "7"
+input_select_btn = "8"
+input_start_btn = "9"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_l_x_plus_btn = "h0right"
+input_l_x_minus_btn = "h0left"
+input_l_y_plus_btn = "h0down"
+input_l_y_minus_btn = "h0up"
+
+input_b_btn_label = "Cross"
+input_y_btn_label = "Square"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_up_btn_label = "Joystick Up"
+input_down_btn_label = "Joystick Down"
+input_left_btn_label = "Joystick Left"
+input_right_btn_label = "Joystick Right"
+input_a_btn_label = "Circle"
+input_x_btn_label = "Triangle"
+input_l_btn_label = "L1"
+input_r_btn_label = "R1"
+input_l2_btn_label = "L2"
+input_r2_btn_label = "R2"
+input_l_x_plus_axis_label = "Joystick Right"
+input_l_x_minus_axis_label = "Joystick Left"
+input_l_y_plus_axis_label = "Joystick Down"
+input_l_y_minus_axis_label = "Joystick Up"


### PR DESCRIPTION
The mapping I got for this controller was incorrect so here is the mapping I created and have been playing with for a few months.

I believe the `ACRUX_QuanBa_Arcade_JoyStick_1008.cfg` is incorrect in calling device `3888:4352` a Q4RAF, I think it's actually a Q1-W 2-in-1 which is quite different.

I can remove the comment or change the name in other config as required.