### PR TITLE
3 dinput profiles had "winxinput" as "input_driver".

### DIFF
--- a/dinput/Logitech_RumblePad_2.cfg
+++ b/dinput/Logitech_RumblePad_2.cfg
@@ -1,4 +1,4 @@
-input_driver = "winxinput"
+input_driver = "dinput"
 input_device = "Logitech RumblePad 2 USB"
 input_device_display_name = "RumblePad 2 Controller"
 

--- a/dinput/Mayflash_USB_Adapter.cfg
+++ b/dinput/Mayflash_USB_Adapter.cfg
@@ -1,4 +1,4 @@
-input_driver = "winxinput"
+input_driver = "dinput"
 input_device = "USB GamePad"
 input_device_display_name = "Mayflash USB Adapter"
 

--- a/dinput/Microsoft_Sidewinder_Game_Pad_USB.cfg
+++ b/dinput/Microsoft_Sidewinder_Game_Pad_USB.cfg
@@ -1,4 +1,4 @@
-input_driver = "winxinput"
+input_driver = "dinput"
 input_device = "SideWinder Game Pad USB version 1.0"
 input_device_display_name = "SideWinder Game Pad"
 


### PR DESCRIPTION
I don't even think it breaks anything by leaving these to "winxinput", but let's make it clean! :) 