### PR TITLE
Add .gitlab-ci.yml file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,20 @@
+stages:
+  - package
+
+.package-base:
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:latest
+  stage: package
+  variables:
+    MEDIA_PATH: .media
+  before_script:
+    - rm -fr configure COPYING .git* Makefile README.md retropad_layout.png .travis.yml verify_duplicate_profiles.rb
+  script:
+    - mkdir -p ${MEDIA_PATH}/${CI_PROJECT_NAME}
+    - cp -R ./* ${MEDIA_PATH}/${CI_PROJECT_NAME}
+  artifacts:
+    paths:
+    - ${MEDIA_PATH}
+    expire_in: 1 day
+
+libretro-package-any:
+  extends: .package-base


### PR DESCRIPTION
This PR adds a `.gitlab-ci.yml` file, required for packaging jobs on the new infrastructure.