### PR TITLE
Disable xinput profile for 8bitdo N30 Modkit

### DIFF
--- a/xinput/8Bitdo_N30_Modkit_BT.cfg
+++ b/xinput/8Bitdo_N30_Modkit_BT.cfg
@@ -3,8 +3,8 @@ input_driver = "xinput"
 input_device = "Bluetooth Wireless Controller   "
 input_device_display_name = "8Bitdo N30 Modkit"
 
-input_vendor_id = "1118"
-input_product_id = "736"
+# input_vendor_id = "1118"
+# input_product_id = "736"
 
 input_b_btn = "0"
 input_select_btn = "7"


### PR DESCRIPTION
This profile conflicts with real Xbox One controllers, leaving over half the controller unmapped in the process. The 8bitdo N30 Modkit supports dinput, so an xinput profile isn't even necessary. I've left the profile disabled rather than removing it in case we have a more elegant way to differentiate in the future, but for now this seems like a necessary change.