### PR TITLE
Update and rename Thrustmaster eSwap Pro PS3.cfg to Thrustmaster eSwa…

### DIFF
--- a/dinput/Thrustmaster eSwap Pro.cfg
+++ b/dinput/Thrustmaster eSwap Pro.cfg
@@ -1,7 +1,10 @@
 input_driver = "dinput"
 input_device = "eSwap PRO Controller"
+input_device_display_name = "Thrustmaster eSwap PRO Controller"
+
 input_vendor_id = "1103"
 input_product_id = "53262"
+
 input_b_btn = "0"
 input_y_btn = "2"
 input_select_btn = "6"


### PR DESCRIPTION
…p Pro.cfg

Added spacing and removed the "PS3" because the controller is for the PS4.