### PR TITLE
Add support for menu toggle to work on SF30 Pro for macOS

### DIFF
--- a/hid/8Bitdo_Pro_SF30_USB.cfg
+++ b/hid/8Bitdo_Pro_SF30_USB.cfg
@@ -10,6 +10,8 @@ input_product_id = "24576"
 input_select_btn = "10"
 input_start_btn = "11"
 
+input_menu_toggle_btn = "12"
+
 input_a_btn = "0"
 input_b_btn = "1"
 input_x_btn = "3"


### PR DESCRIPTION
I tested with my SF30 Pro on RetroArch 1.9.7 for macOS. This change makes menu toggle work.