### PR TITLE
fix for 8Bitdo M30 Bluetooth controller layout

### DIFF
--- a/dinput/8Bitdo_M30_BT.cfg
+++ b/dinput/8Bitdo_M30_BT.cfg
@@ -1,5 +1,5 @@
 # 8BitDo M30 BT          - http://www.8bitdo.com/     - http://www.8bitdo.com/m30/
-# Firmware v1.13         - http://support.8bitdo.com/
+# Firmware v1.14         - http://support.8bitdo.com/
 
 input_driver = "dinput"
 input_device = "Bluetooth Wireless Controller   "
@@ -10,27 +10,29 @@ input_product_id = "1617"
 
 # ---------------------------------------
 
-input_b_btn = "0"
-input_y_btn = "3"
+input_b_btn = "1"
+input_y_btn = "0"
 input_select_btn = "10"
 input_start_btn = "11"
-input_a_btn = "1"
+input_a_btn = "7"
 input_x_btn = "4"
-input_l_btn = "8"
-input_r_btn = "9"
-input_l2_btn = "6"
-input_r2_btn = "7"
+input_l_btn = "3"
+input_r_btn = "6"
+input_l2_btn = "8"
+input_r2_btn = "9"
+input_menu_toggle_btn = "2"
 
-input_b_btn_label = "A"
-input_y_btn_label = "X"
-input_select_btn_label = "MODE"
+input_b_btn_label = "B"
+input_y_btn_label = "A"
+input_select_btn_label = "Minus (-)"
 input_start_btn_label = "START"
-input_a_btn_label = "B"
+input_a_btn_label = "C"
 input_x_btn_label = "Y"
-input_l_btn_label = "L"
-input_r_btn_label = "R"
-input_l2_btn_label = "Z"
-input_r2_btn_label = "C"
+input_l_btn_label = "X"
+input_r_btn_label = "Z"
+input_l2_btn_label = "L"
+input_r2_btn_label = "R"
+input_menu_toggle_btn = "Heart"
 
 # ---------------------------------------
 


### PR DESCRIPTION
The 8Bitdo M30 autoconf profile currently in the repo has counter-intuitive mappings.

One could argue the use case for this 6 face button controller is primarily MD/Gen/Saturn. However the current profile is mapped after the standard SNES layout. This can be confusing for new users. The issue was discussed on the forums [here](https://forums.libretro.com/t/8bitdo-m30-w-retroarch/21175) and [there](https://forums.libretro.com/t/problem-assigning-autoconfig-values-to-m30-bluetooth-controller/30656) among others and solved by @hunterk and SirBedwyr.

This corrected profile makes the MD/Gen experience plug & play (and remaps for other systems much less confusing).

- corrected layout as LXR/YBA
- renamed "MODE" as "Minus (-)" to reflect the actual name of the button on the controller
- added button map for menu toggle ("Heart" button on the controller )

The x-input / udev and other drivers may need to be amended with the same changes.