### PR TITLE
Add Elecom JC-W01U Wii USB Gamepad Converter for hid

### DIFF
--- a/hid/Elecom_JC-W01U.cfg
+++ b/hid/Elecom_JC-W01U.cfg
@@ -1,0 +1,22 @@
+# Elecom JC-W01U Wii USB Gamepad Converter
+# mapped buttons for official SNES/SFC Wii Controller
+
+input_driver = "hid"
+input_device = "JC-W01U"
+input_device_display_name = "Elecom JC-W01U Wii USB Gamepad Converter"
+input_vendor_id = "1390"
+input_product_id = "8199"
+input_b_btn = "2"
+input_y_btn = "0"
+input_select_btn = "8"
+input_start_btn = "9"
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+input_a_btn = "3"
+input_x_btn = "1"
+input_l_btn = "4"
+input_r_btn = "5"
+input_l2_btn = "6"
+input_r2_btn = "6"


### PR DESCRIPTION
- Elecom JC-W01U Wii USB Gamepad Converter ([web link](https://www.elecom.co.jp.e.gj.hp.transer.com/products/JC-W01UWH.html))
- mapped buttons for official SNES/SFC Wii Controller