### PR TITLE
fix ds4v1 support on "modern" linux distros

### DIFF
--- a/udev/Sony-PlayStation4-DualShock4-Controller.cfg
+++ b/udev/Sony-PlayStation4-DualShock4-Controller.cfg
@@ -1,31 +1,41 @@
+# IMPORTANT NOTICE !!!
+#
+# This profile uses the native official kernel module "hid_sony" which is maintained and has been present for a fairly long time now
+# The userspace tool "ds4drv" mapped this differently, but "ds4drv" has been deprecated since 2017
+# Sadly there is currently no way for retroarch to tell which of the kernel module or the userspace tool is in use
+# Because of this, we must consider the user is using the modern recommended method here
+# Users that would still be using "ds4drv" should migrate to the modern method
+#
+# FOR CONSISTENCY'S SAKE, PLEASE DON'T REVERT THIS TO THE DS4DRV WAY ANYMORE !!!
+
 input_driver = "udev"
 input_device = "Sony Computer Entertainment Wireless Controller"
 input_vendor_id = "1356"
 input_product_id = "1476"
-input_b_btn = "1"
-input_y_btn = "0"
+input_b_btn = "0"
+input_y_btn = "3"
 input_select_btn = "8"
 input_start_btn = "9"
 input_up_btn = "h0up"
 input_down_btn = "h0down"
 input_left_btn = "h0left"
 input_right_btn = "h0right"
-input_a_btn = "2"
-input_x_btn = "3"
+input_a_btn = "1"
+input_x_btn = "2"
 input_l_btn = "4"
 input_r_btn = "5"
 input_l2_btn = "6"
 input_r2_btn = "7"
-input_l3_btn = "10"
-input_r3_btn = "11"
+input_l3_btn = "11"
+input_r3_btn = "12"
 input_l_x_plus_axis = "+0"
 input_l_x_minus_axis = "-0"
 input_l_y_plus_axis = "+1"
 input_l_y_minus_axis = "-1"
-input_r_x_plus_axis = "+2"
-input_r_x_minus_axis = "-2"
-input_r_y_plus_axis = "+5"
-input_r_y_minus_axis = "-5"
+input_r_x_plus_axis = "+3"
+input_r_x_minus_axis = "-3"
+input_r_y_plus_axis = "+4"
+input_r_y_minus_axis = "-4"
 input_menu_toggle_btn = "10"
 
 input_b_btn_label = "Cross"


### PR DESCRIPTION
See additional comments on https://github.com/libretro/retroarch-joypad-autoconfig/commit/336f2a563f267bffe40600361cd124c0564f9f79