### PR TITLE
Add Retrode 2 USB adapter

### DIFF
--- a/hid/Retrode_2.cfg
+++ b/hid/Retrode_2.cfg
@@ -1,0 +1,33 @@
+#
+# Retrode 2 USB adapter for original SNES and MegaDrive/Genesis gamepads - https://www.retrode.com
+#
+input_driver = "hid"
+input_device = "Retrode"
+input_vendor_id = "1027"
+input_product_id = "38849"
+input_b_btn = "0"
+input_y_btn = "1"
+input_select_btn = "2"
+input_start_btn = "3"
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_a_btn = "8"
+input_x_btn = "9"
+input_l_btn = "10"
+input_r_btn = "11"
+
+input_b_btn_label = "B"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+
+input_up_axis_label = "Dpad Up"
+input_down_axis_label = "Dpad Down"
+input_left_axis_label = "Dpad Left"
+input_right_axis_label = "Dpad Right"


### PR DESCRIPTION
Tested on Wii and Wii U.

I provided dinput and udev files already some years ago.