### PR TITLE
Add 8BitDo M30 2.4g config

### DIFF
--- a/sdl2/8Bitdo_M30_24G.cfg
+++ b/sdl2/8Bitdo_M30_24G.cfg
@@ -1,0 +1,79 @@
+# 8BitDo M30 2.4g controller
+# https://www.8bitdo.com/m30-2-4g-for-genesis-mini-mega-drive-mini/
+# https://support.8bitdo.com/
+# Credit to https://github.com/j68k for comments and tidiness that I copied:
+# https://github.com/libretro/retroarch-joypad-autoconfig/blob/master/dinput/8Bitdo_M30_BT.cfg
+
+# This configuration is for when the controller is connected by 2.4GHz dongle.
+# When connecting via USB, the controller presents as Xbox 360 Controller.
+# The controller presents the same IDs as
+# ../udev/SEGA_Mega_Drive_Mini_6B_Controller.cfg but it runs different driver.
+
+input_device_display_name = "8BitDo M30 2.4g"
+
+input_driver = "sdl2"
+input_device = "6B controller"
+input_vendor_id = "3235"
+input_product_id = "36"
+
+# The RetroPad layout has four face buttons, whereas the M30 has six. We map
+# the M30's L and R buttons to the RetroPad's triggers, and map the M30's Z and
+# C buttons to the RetroPad's left and right shoulder buttons respectively.
+# That may seem somewhat counterintuitive but it follows the convention that is
+# used in many cores for systems that have six face buttons in this layout.
+# That allows the controller to be autoconfigured and work in the natural way
+# in the Beetle Saturn core, and in 6-button fighting games in the
+# FinalBurn Neo and MAME cores.
+
+# Config tested with PicoDrive Remap below with 6 Button Controller option.
+# Tested against "Controller Test" ROM: https://www.romhacking.net/homebrew/126/
+
+# ../../config/remaps/PicoDrive/PicoDrive.rmp
+# input_libretro_device_p1 = "1"
+# input_player1_analog_dpad_mode = "0"
+# input_player1_btn_up = "6"
+# input_player1_btn_down = "7"
+# input_player1_btn_left = "4"
+# input_player1_btn_right = "5"
+# input_player1_btn_a = "0"
+# input_player1_btn_b = "1"
+# input_player1_btn_y = "10"
+# input_player1_btn_l = "11"
+# input_player1_btn_r = "8"
+
+
+# Buttons:
+input_a_btn = "1"
+input_b_btn = "2"
+input_x_btn = "0"
+input_y_btn = "3"
+input_l_btn = "4"
+input_r_btn = "5"
+input_l2_btn = "6"
+input_r2_btn = "7"
+input_select_btn = "8"
+input_start_btn = "9"
+#input_menu_toggle_btn = "8" Same response as Minus
+
+input_a_btn_label = "B"
+input_b_btn_label = "A"
+input_x_btn_label = "Y"
+input_y_btn_label = "X"
+input_l_btn_label = "Z"
+input_r_btn_label = "C"
+input_l2_btn_label = "L"
+input_r2_btn_label = "R"
+input_select_btn_label = "Minus (-)"
+input_start_btn_label = "Start"
+#input_menu_toggle_btn_label = "Heart" Same response as Minus
+
+# D-Pad:
+input_up_axis = "-0"
+input_down_axis = "+0"
+input_left_axis = "-1"
+input_right_axis = "+1"
+
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"


### PR DESCRIPTION
Create controller config for 2.4GHz variant of 8BitDo M30 controller with bias toward RetroPad behavior. PicoDrive remamp suggestion included in comments.