### PR TITLE
Analog inputs plus correct default d-pad inputs

### DIFF
--- a/dinput/8Bitdo_SN30_GP_BT.cfg
+++ b/dinput/8Bitdo_SN30_GP_BT.cfg
@@ -3,7 +3,7 @@
 
 input_driver = "dinput"
 input_device = "Bluetooth Wireless Controller   "
-input_device_display_name = "8Bitdo SN30 GP"
+input_device_display_name = "8Bitdo SN30 GP (dinput)"
 
 # Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retroarch.cfg and run RetroArch.
 # Hex vid:pid = 2DC8:2862 -> Decimal vid:pid = 11720:10338
@@ -21,19 +21,39 @@ input_r_btn = "7"
 
 input_b_btn_label = "B"
 input_y_btn_label = "Y"
-input_select_btn_label = "Select"
-input_start_btn_label = "Start"
+input_select_btn_label = "-select"
+input_start_btn_label = "+start"
 input_a_btn_label = "A"
 input_x_btn_label = "X"
 input_l_btn_label = "L"
 input_r_btn_label = "R"
 
-input_up_axis = "-1"
-input_down_axis = "+1"
-input_left_axis = "-0"
-input_right_axis = "+0"
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
 
-input_up_axis_label = "Dpad Up"
-input_down_axis_label = "Dpad Down"
-input_left_axis_label = "Dpad Left"
-input_right_axis_label = "Dpad Right"
+input_up_btn_label = "D-Pad Up (D-Pad Mode)"
+input_down_btn_label = "D-Pad Down (D-Pad Mode)"
+input_left_btn_label = "D-Pad Left (D-Pad Mode)"
+input_right_btn_label = "D-Pad Right (D-Pad Mode)"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+
+input_l_x_plus_axis_label = "D-Pad Right (L Analog Mode)"
+input_l_x_minus_axis_label = "D-Pad Left (L Analog Mode)"
+input_l_y_plus_axis_label = "D-Pad Down (L Analog Mode)"
+input_l_y_minus_axis_label = "D-Pad Up (L Analog Mode)"
+
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+5"
+input_r_y_minus_axis = "-5"
+
+input_r_x_plus_axis_label = "D-Pad Right (R Analog Mode)"
+input_r_x_minus_axis_label = "D-Pad Left (R Analog Mode)"
+input_r_y_plus_axis_label = "D-Pad Down (R Analog Mode)"
+input_r_y_minus_axis_label = "D-Pad Up (R Analog Mode)"


### PR DESCRIPTION
Change 8Bitdo SN30 GP BT file to add Analog inputs when using respective modes (Select + Left, Up and Right for Left Analog, D-Pad and Right Analog respectively) Also change default input axis to hat, as default input mode is D-Pad (Which is not an Axis)