### PR TITLE
Update Odin_Handheld.cfg

### DIFF
--- a/android/Odin_Handheld.cfg
+++ b/android/Odin_Handheld.cfg
@@ -1,7 +1,5 @@
 input_driver = "android"
 input_device = "Odin Handheld"
-input_vendor_id = "8224"
-input_product_id = "273"
 input_device_display_name = "Ayn Odin"
 input_b_btn = "97"
 input_b_btn_label = "B"


### PR DESCRIPTION
Fix conflict with another profile. This profile currently conflicts with another profile from a completely different device. Removing these two fields will allow both profiles to work as intended for the time being.