### PR TITLE
Adds Onn Remote support for menu navigation

### DIFF
--- a/android/Onn-Remote.cfg
+++ b/android/Onn-Remote.cfg
@@ -1,0 +1,24 @@
+input_driver = "android"
+input_device = "Onn-Remote"
+input_device_display_name = "Onn Remote Control"
+input_device_type = "remote"
+input_vendor_id = 2391
+input_product_id = 5
+
+input_b_btn = "23"
+input_up_btn = "19"
+input_down_btn = "20"
+input_left_btn = "21"
+input_right_btn = "22"
+input_a_btn = "4"
+input_y_btn = "84"
+input_menu_toggle_btn = "4"
+
+input_b_btn_label = "Back"
+input_up_btn_label = "Up"
+input_down_btn_label = "Down"
+input_left_btn_label = "Left"
+input_right_btn_label = "Right"
+input_a_btn_label = "Center"
+input_y_btn_label = "Search"
+input_menu_toggle_btn_label = "Back"


### PR DESCRIPTION
Ready to be merged, brings support on board for Walmart's Onn 4k streamer Part No 100026240.

https://www.walmart.com/ip/onn-Android-TV-4K-UHD-Streaming-Device-with-Voice-Remote-Control-HDMI-Cable/636597403

Also to note - I had to flip the values for b and a from what the default Android TV cfg had, but it seems to be working fine now. Also reset my controllers configs just to make sure I had no active remaps happening on top of the default config.

What the values are now
```
input_b_btn = "23"
input_a_btn = "4"
```



~~Work in progress.. the D-Pad controls appear to work fine, but select and back appear to be non-functional at the moment. Creating this PR however for additional visibility to the problem. Also inclusion may still be warranted as partial support is better than no support and I have only tested it against a single Onn 4k streaming device, I believe there are others.~~

~~I have confirmed though that button values appear to match the back button and select buttons, so I am not sure what the actual hang up is. May have to root the device later and do some more digging. Also not sure if adding the vendor and product id to the config file would help any or not, I have not yet pulled that info to add it, but it appears like it isn't needed for it to apply the config still.~~

~~On another not I do feel like it is a mistake by the upstream retroarch repo to not push all of these controller configs into the user writable directory by default on Android vs expecting users to figure out where to go to reset the controller config directory.~~