### PR TITLE
Update Raphnet 1-player WUSBMote to v2.2

### DIFF
--- a/dinput/raphnet-tech_1-player_WUSBMote_v2.2.cfg
+++ b/dinput/raphnet-tech_1-player_WUSBMote_v2.2.cfg
@@ -1,4 +1,4 @@
-input_device = "1-player WUSBMote v2.1"
+input_device = "1-player WUSBMote v2.2"
 input_driver = "dinput"
 
 input_product_id = "43"
@@ -25,6 +25,8 @@ input_r2_btn = "9"
 input_r2_btn_label = "Zr"
 input_l2_btn = "8"
 input_l2_btn_label = "Zl"
+input_menu_toggle_btn = "10"
+input_menu_toggle_btn_label = "Home"
 
 # D-Pad
 input_left_btn = "14"


### PR DESCRIPTION
Changes:
 1) Changed version from v2.1 to v2.2 because RetroArch wouldn't detect the adapter without this change.
 2) Added a mapping for the Wii Classic controller's Home button.