### PR TITLE
Update Nintendo - Switch Pro Controller.cfg

### DIFF
--- a/udev/Nintendo - Switch Pro Controller.cfg
+++ b/udev/Nintendo - Switch Pro Controller.cfg
@@ -1,5 +1,5 @@
 # Nintendo Switch Pro Controller (with nintendo-hid)
-# Without nintendo-hid, various features such as vibration, gyro, and USB support are unavailable. It appears this will be included in the Linux kernel beginning with version 5.10.
+# Without nintendo-hid, various features such as vibration, gyro, and USB support are unavailable. It appears this will be included in the Linux kernel beginning with version 5.16 (https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16).
 # The easiest solution for most users is to install the nintendo-hid DKMS module, available from https://github.com/nicman23/dkms-hid-nintendo/
 # Screenshot button (circle) is unbound in this autoconf, but has an ID of 4
 

--- a/udev/Nintendo - Switch Pro Controller.cfg
+++ b/udev/Nintendo - Switch Pro Controller.cfg
@@ -1,5 +1,10 @@
 # Nintendo Switch Pro Controller (with nintendo-hid)
-# Without nintendo-hid, various features such as vibration, gyro, and USB support are unavailable. It appears this will be included in the Linux kernel beginning with version 5.16 (https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16).
+# With nintendo-hid, various features such as vibration, gyro, and USB support are available. It appears this will be included in the Linux kernel beginning with version 5.16:
+# "Pull HID updates from Jiri Kosina:
+#
+#    - support for Nintendo Switch Pro Controllers and Joy-Cons (Daniel J.
+#      Ogorchock)" - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16
+# 
 # The easiest solution for most users is to install the nintendo-hid DKMS module, available from https://github.com/nicman23/dkms-hid-nintendo/
 # Screenshot button (circle) is unbound in this autoconf, but has an ID of 4
 


### PR DESCRIPTION
It appears this will be included in the Linux kernel beginning with version 5.16 (https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16).