### PR TITLE
Update Nintendo Switch Left Joy-Con.cfg

### DIFF
--- a/udev/Nintendo Switch Left Joy-Con.cfg
+++ b/udev/Nintendo Switch Left Joy-Con.cfg
@@ -1,6 +1,5 @@
-# Information added to "udev/Nintendo - Switch Pro Controller.cfg", "udev/Nintendo - Switch Pro Controller (bare).cfg", "udev/Nintendo Switch Left Joy-Con.cfg", and "udev/Nintendo Switch Right Joy-Con.cfg":
-# Without nintendo-hid, various features such as vibration, gyro, and USB support are unavailable.
-# It appears this will be included in the Linux kernel beginning with version 5.16:
+# Nintendo Switch Left Joy-Con (with nintendo-hid)
+# With nintendo-hid, various features such as vibration, gyro, and USB support are available. It appears this will be included in the Linux kernel beginning with version 5.16:
 # "Pull HID updates from Jiri Kosina:
 #
 #    - support for Nintendo Switch Pro Controllers and Joy-Cons (Daniel J.


### PR DESCRIPTION
```
# Information added to "udev/Nintendo - Switch Pro Controller.cfg", "udev/Nintendo - Switch Pro Controller (bare).cfg", "udev/Nintendo Switch Left Joy-Con.cfg", and "udev/Nintendo Switch Right Joy-Con.cfg": # Without nintendo-hid, various features such as vibration, gyro, and USB support are unavailable. # It appears this will be included in the Linux kernel beginning with version 5.16: # "Pull HID updates from Jiri Kosina:
#
#    - support for Nintendo Switch Pro Controllers and Joy-Cons (Daniel J.
#      Ogorchock)" - https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.16
```
