### PR TITLE
Update and rename Nintendo - Switch Pro Controller (bare).cfg to Nint…

### DIFF
--- a/udev/Nintendo - Switch Pro Controller (old).cfg
+++ b/udev/Nintendo - Switch Pro Controller (old).cfg
@@ -11,7 +11,7 @@
 
 input_driver = "udev"
 input_device = "Pro Controller"
-input_device_display_name = "Nintendo Switch Pro Controller (bare)"
+input_device_display_name = "Nintendo Switch Pro Controller (old)"
 
 # input_vendor_id = "1406"
 # input_product_id = "8201"


### PR DESCRIPTION
…endo - Switch Pro Controller (old).cfg

To make it consistent with https://github.com/libretro/retroarch-joypad-autoconfig/blob/master/sdl2/Nintendo%20Switch%20Pro%20Controller%20(old).cfg