### PR TITLE
Add support for the 8BitDo Ultimate C Wired controller in X-Input mode.

### DIFF
--- a/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
+++ b/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
@@ -9,7 +9,8 @@
 # hardware turbo button.
 
 input_driver = "sdl2"
-input_device = "8BitDo Ultimate C Wired Controller"
+# The device name has a trailing space
+input_device = "8BitDo Ultimate C Wired Controller "
 input_device_display_name = "8BitDo Ultimate C Wired Controller"
 
 # 2dc8:3106

--- a/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
+++ b/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
@@ -1,0 +1,79 @@
+# 8BitDo Ultimate C Wired Controller
+# https://www.8bitdo.com/ - https://www.8bitdo.com/ultimate-c-wired-controller/
+# https://support.8bitdo.com/ - https://support.8bitdo.com/firmware-updater.html
+# 
+# This is with the device started in PC (X-Input) mode, by holding the
+# X button while plugging in the controller.
+# 
+# The star button cannot be mapped in X-Input mode and functions as a
+# hardware turbo button.
+
+input_driver = "sdl2"
+input_device = "8BitDo Ultimate C Wired Controller"
+input_device_display_name = "8BitDo Ultimate C Wired Controller"
+
+# 2dc8:3106
+input_vendor_id = "11720"
+input_product_id = "12550"
+
+input_up_btn = "11"
+input_down_btn = "12"
+input_left_btn = "13"
+input_right_btn = "14"
+
+input_a_btn = "1"
+input_b_btn = "0"
+input_x_btn = "3"
+input_y_btn = "2"
+
+input_select_btn = "4"
+input_start_btn = "6"
+input_menu_toggle_btn = "5"
+
+input_l_btn = "9"
+input_r_btn = "10"
+input_l2_axis = "+4"
+input_r2_axis = "+5"
+input_l3_btn = "7"
+input_r3_btn = "8"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
+
+input_gun_trigger_mbtn = "1"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"
+
+input_b_btn_label = "A"
+input_a_btn_label = "B"
+input_y_btn_label = "X"
+input_x_btn_label = "Y"
+
+input_select_btn_label = "View"
+input_start_btn_label = "Menu"
+input_menu_toggle_btn_label = "Home"
+
+input_l_btn_label = "LB"
+input_r_btn_label = "RB"
+input_l2_btn_label = "LT"
+input_r2_btn_label = "RT"
+input_l3_btn_label = "LSB"
+input_r3_btn_label = "RSB"
+
+input_l_x_plus_axis_label = "LS Right"
+input_l_x_minus_axis_label = "LS Left"
+input_l_y_plus_axis_label = "LS Down"
+input_l_y_minus_axis_label = "LS Up"
+input_r_x_plus_axis_label = "RS Right"
+input_r_x_minus_axis_label = "RS Left"
+input_r_y_plus_axis_label = "RS Down"
+input_r_y_minus_axis_label = "RS Up"

--- a/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
+++ b/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
@@ -5,8 +5,7 @@
 # This is with the device started in PC (X-Input) mode, by holding the
 # X button while plugging in the controller.
 # 
-# The star button cannot be mapped in X-Input mode and functions as a
-# hardware turbo button.
+# The star button cannot be mapped and functions as a hardware turbo button.
 
 input_driver = "sdl2"
 # The device name has a trailing space

--- a/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
+++ b/sdl2/8BitDo_Ultimate_C_Wired_Controller.cfg
@@ -46,8 +46,6 @@ input_r_x_minus_axis = "-2"
 input_r_y_plus_axis = "+3"
 input_r_y_minus_axis = "-3"
 
-input_gun_trigger_mbtn = "1"
-
 input_up_btn_label = "Dpad Up"
 input_down_btn_label = "Dpad Down"
 input_left_btn_label = "Dpad Left"

--- a/udev/8BitDo_Ultimate_C_Wired_Controller.cfg
+++ b/udev/8BitDo_Ultimate_C_Wired_Controller.cfg
@@ -9,7 +9,8 @@
 # hardware turbo button.
 
 input_driver = "udev"
-input_device = "8BitDo Ultimate C Wired Controller"
+# The device name has a trailing space
+input_device = "8BitDo Ultimate C Wired Controller "
 input_device_display_name = "8BitDo Ultimate C Wired Controller"
 
 # 2dc8:3106

--- a/udev/8BitDo_Ultimate_C_Wired_Controller.cfg
+++ b/udev/8BitDo_Ultimate_C_Wired_Controller.cfg
@@ -46,8 +46,6 @@ input_r_x_minus_axis = "-3"
 input_r_y_plus_axis = "+4"
 input_r_y_minus_axis = "-4"
 
-input_gun_trigger_mbtn = "1"
-
 input_up_btn_label = "Dpad Up"
 input_down_btn_label = "Dpad Down"
 input_left_btn_label = "Dpad Left"

--- a/udev/8BitDo_Ultimate_C_Wired_Controller.cfg
+++ b/udev/8BitDo_Ultimate_C_Wired_Controller.cfg
@@ -1,0 +1,79 @@
+# 8BitDo Ultimate C Wired Controller
+# https://www.8bitdo.com/ - https://www.8bitdo.com/ultimate-c-wired-controller/
+# https://support.8bitdo.com/ - https://support.8bitdo.com/firmware-updater.html
+# 
+# This is with the device started in PC (X-Input) mode, by holding the
+# X button while plugging in the controller.
+# 
+# The star button cannot be mapped in X-Input mode and functions as a
+# hardware turbo button.
+
+input_driver = "udev"
+input_device = "8BitDo Ultimate C Wired Controller"
+input_device_display_name = "8BitDo Ultimate C Wired Controller"
+
+# 2dc8:3106
+input_vendor_id = "11720"
+input_product_id = "12550"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_a_btn = "1"
+input_b_btn = "0"
+input_x_btn = "3"
+input_y_btn = "2"
+
+input_select_btn = "6"
+input_start_btn = "7"
+input_menu_toggle_btn = "8"
+
+input_l_btn = "4"
+input_r_btn = "5"
+input_l2_axis = "+2"
+input_r2_axis = "+5"
+input_l3_btn = "9"
+input_r3_btn = "10"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+3"
+input_r_x_minus_axis = "-3"
+input_r_y_plus_axis = "+4"
+input_r_y_minus_axis = "-4"
+
+input_gun_trigger_mbtn = "1"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"
+
+input_b_btn_label = "A"
+input_a_btn_label = "B"
+input_y_btn_label = "X"
+input_x_btn_label = "Y"
+
+input_select_btn_label = "View"
+input_start_btn_label = "Menu"
+input_menu_toggle_btn_label = "Home"
+
+input_l_btn_label = "LB"
+input_r_btn_label = "RB"
+input_l2_btn_label = "LT"
+input_r2_btn_label = "RT"
+input_l3_btn_label = "LSB"
+input_r3_btn_label = "RSB"
+
+input_l_x_plus_axis_label = "LS Right"
+input_l_x_minus_axis_label = "LS Left"
+input_l_y_plus_axis_label = "LS Down"
+input_l_y_minus_axis_label = "LS Up"
+input_r_x_plus_axis_label = "RS Right"
+input_r_x_minus_axis_label = "RS Left"
+input_r_y_plus_axis_label = "RS Down"
+input_r_y_minus_axis_label = "RS Up"

--- a/udev/8BitDo_Ultimate_C_Wired_Controller_DInput.cfg
+++ b/udev/8BitDo_Ultimate_C_Wired_Controller_DInput.cfg
@@ -1,20 +1,25 @@
 # 8BitDo Ultimate C Wired Controller
 # https://www.8bitdo.com/ - https://www.8bitdo.com/ultimate-c-wired-controller/
 # https://support.8bitdo.com/ - https://support.8bitdo.com/firmware-updater.html
-# 
-# This is with the device started in PC (X-Input) mode, by holding the
-# X button while plugging in the controller.
-# 
+#
+# This is with the device started in D-Input mode, by holding the B button
+# while plugging in the controller.
+#
 # The star button cannot be mapped and functions as a hardware turbo button.
+#
+# In D-Input mode, the left and right triggers emit two events. One EV_KEY
+# (a binary button press) and one EV_ABS (a continuous analog input). The
+# analog inputs are mapped here and the button inputs are documented in
+# comments below.
 
 input_driver = "udev"
 # The device name has a trailing space
 input_device = "8BitDo Ultimate C Wired Controller "
-input_device_display_name = "8BitDo Ultimate C Wired Controller"
+input_device_display_name = "8BitDo Ultimate C Wired Controller (D-Input)"
 
-# 2dc8:3106
+# 2dc8:3017
 input_vendor_id = "11720"
-input_product_id = "12550"
+input_product_id = "12311"
 
 input_up_btn = "h0up"
 input_down_btn = "h0down"
@@ -23,28 +28,30 @@ input_right_btn = "h0right"
 
 input_a_btn = "1"
 input_b_btn = "0"
-input_x_btn = "3"
-input_y_btn = "2"
+input_x_btn = "4"
+input_y_btn = "3"
 
-input_select_btn = "6"
-input_start_btn = "7"
-input_menu_toggle_btn = "8"
+input_select_btn = "10"
+input_start_btn = "11"
+input_menu_toggle_btn = "12"
 
-input_l_btn = "4"
-input_r_btn = "5"
-input_l2_axis = "+2"
-input_r2_axis = "+5"
-input_l3_btn = "9"
-input_r3_btn = "10"
+input_l_btn = "6"
+input_r_btn = "7"
+input_l2_btn = "+10"
+# Non-analog button press: input_l2_btn = "8"
+input_r2_btn = "+9"
+# Non-analog button press: input_r2_btn = "9"
+input_l3_btn = "13"
+input_r3_btn = "14"
 
 input_l_x_plus_axis = "+0"
 input_l_x_minus_axis = "-0"
 input_l_y_plus_axis = "+1"
 input_l_y_minus_axis = "-1"
-input_r_x_plus_axis = "+3"
-input_r_x_minus_axis = "-3"
-input_r_y_plus_axis = "+4"
-input_r_y_minus_axis = "-4"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
 
 input_up_btn_label = "Dpad Up"
 input_down_btn_label = "Dpad Down"


### PR DESCRIPTION
Both udev and sdl2 config files are provided. The sdl2 config is particularly useful for the Retroarch Flatpak, which uses the sdl2 driver by default.

I do not have a Windows license, so this is Linux support only.