### PR TITLE
make: Clean up make install usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ all:
 
 install:
 	for driver in android dinput hid linuxraw mfi parport qnx sdl2 udev x xinput; do \
-		install -Dm644 -t $(DESTDIR)$(INSTALLDIR)/$$driver $$driver/*.cfg; \
+		for file in $$driver/*.cfg; do \
+			install -Dm644 -t $(DESTDIR)$(INSTALLDIR)/$$driver "$$file"; \
+		done \
 	done
 	install -Dm644 -t $(DESTDIR)$(DOC_DIR) COPYING README.md retropad_layout.png
 


### PR DESCRIPTION
This fixes warnings that often happened on make install via Lakka.

```
<<< retroarch_joypad_autoconfig:target seq 11 <<<
sha256sum: packages/lakka/retroarch_base/retroarch_joypad_autoconfig/joypad_configs/udev/Nintendo: No such file or directory
sha256sum: Switch: No such file or directory
sha256sum: Left: No such file or directory
sha256sum: Joy-Con.cfg: No such file or directory
sha256sum: packages/lakka/retroarch_base/retroarch_joypad_autoconfig/joypad_configs/udev/Nintendo: No such file or directory
sha256sum: Switch: No such file or directory
sha256sum: Right: No such file or directory
sha256sum: Joy-Con.cfg: No such file or directory
```
