### PR TITLE
Add dinput config for 8BitDo N64 Modkit

### DIFF
--- a/dinput/8Bitdo_N64_Modkit.cfg
+++ b/dinput/8Bitdo_N64_Modkit.cfg
@@ -1,0 +1,76 @@
+# 8BitDo N64 Modkit           - http://www.8bitdo.com/     - https://shop.8bitdo.com/products/8bitdo-mod-kit-for-original-n64-controller
+# Firmware v1.00              - http://support.8bitdo.com/
+# This is with the device started in Android (D-Input) mode.
+# Note: USB and Bluetooth connections have the same PID.
+# Note: Switch mode uses the NSO N64 controller's VID/PID instead.
+
+input_driver = "dinput"
+input_device = "8BitDo N64 Modkit"
+input_device_display_name = "8BitDo N64 Modkit"
+
+# Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retrorch.cfg and run RetroArch.
+# Hex vid:pid = 2DC8:2869 -> Decimal vid:pid = 11720:10345
+
+input_vendor_id = "11720"
+input_product_id = "10345"
+
+# The controller's physical layout matches the NSO N64 controller, and so the
+# button mappings and labels mirror N64_Nintendo_Switch_Online.cfg. However, the
+# D-Input button numbers differ (unless the controller is put in Switch mode).
+#
+# These mappings share some features and quirks with the NSO controller:
+#
+# 1. The mappings work out of the box with default Mupen64Plus-Next core config.
+# 2. The button labeled "B" is mapped to Y on the RetroPad (for Mupen)... and
+#    also to A on the retropad. This duplicate mapping is ignored in Mupen by
+#    default, but enables RetroArch menu navigation.
+# 3. The button labeled "ZR" is mapped to Select on the RetroPad, not R2. This
+#    seems a bit strange, but may have been intended to allow viewing help text
+#    in RetroArch menus.
+#
+# Unfortunately, this controller reports C buttons using the right stick axes in
+# D-Input mode, so it cannot report simultaneous C Up/C Down or C Left/C Right
+# presses. That's a limitation of the controller itself, not this config file.
+
+input_b_btn = "0"
+input_a_btn = "1"
+input_y_btn = "1"
+input_start_btn = "11"
+input_select_btn = "9"
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+input_l_btn = "6"
+input_r_btn = "7"
+input_l2_btn = "8"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+5"
+input_r_y_minus_axis = "-5"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_menu_toggle_btn = "12"
+
+input_b_btn_label = "A"
+input_y_btn_label = "B"
+input_start_btn_label = "Start"
+input_select_btn_label = "ZR"
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "Z"
+input_r_x_plus_axis_label = "C Right"
+input_r_x_minus_axis_label = "C Left"
+input_r_y_minus_axis_label = "C Up"
+input_r_y_plus_axis_label = "C Down"
+input_l_x_plus_axis_label = "Joystick Right"
+input_l_x_minus_axis_label = "Joystick Left"
+input_l_y_plus_axis_label = "Joystick Down"
+input_l_y_minus_axis_label = "Joystick Up"
+input_menu_toggle_btn_label = "Home"


### PR DESCRIPTION
The [8BitDo N64 Modkit](https://shop.8bitdo.com/products/8bitdo-mod-kit-for-original-n64-controller) is a replacement PCB and "rumble pak" that converts an OEM N64 Controller to a USB/Bluetooth controller with two modes: one that emulates an NSO N64 controller (for which there are already autoconfig files), and the other that presents as a normal DirectInput controller with a unique PID/VID. This pull request adds a `dinput` config file for the second mode of operation.

I tried to the match the formatting of the other 8BitDo `dinput` configs, but since the controller physically offers the same buttons as the NSO N64 Controller (including addition of ZR and Home buttons), I used the same RetroPad mappings as the existing `N64_Nintendo_Switch_Online.cfg` (with DirectInput button/axis numbers changed appropriately).

I tested this on the Mupen64Plus-Next core, and it seems to work fine.

Note that I don't love the compromises these mappings (and the equivalent NSO N64 mappings) make for the controller to work with both default Mupen config and RetroArch menus. In particular, double-binding the controller's physical "B" button to enable menu navigation is a hack, and the end result still leaves menu OK/cancel flipped vs. a normal controller. But honestly, the RetroPad abstraction doesn't work very well with controllers whose face buttons aren't laid out like a SNES or DualShock pad, and I suspect the NSO controller mappings are the least bad choice to make under the circumstances.

I don't have a Linux setup running RetroArch right now, so I didn't add a corresponding `udev` config, though it should be easy for someone else to do so if they want.