### PR TITLE
Add udev autoconfiguration PowerA Wireless Controller

### DIFF
--- a/udev/PowerA_Wireless_Controller_for_Nintendo_Switch.cfg
+++ b/udev/PowerA_Wireless_Controller_for_Nintendo_Switch.cfg
@@ -1,0 +1,63 @@
+input_driver = "udev"
+input_device_display_name = "PowerA Wireless Controller for Nintendo Switch"
+# VID copied from other PowerA configuration files.
+# Controller does not recognise as a USB device and, therefore has no VID/PID.
+# Happy to be proven wrong.
+# hex = 20D6
+#input_vendor_id = "8406"
+#input_product_id = ""
+
+#However, this line correctly configures the controller
+input_device = "Lic2 Pro Controller"
+
+input_up_btn_label = "Control Pad ↑"
+input_up_btn = "h0up"
+input_down_btn_label = "Control Pad ↓"
+input_down_btn = "h0down"
+input_left_btn_label = "Control Pad ←"
+input_left_btn = "h0left"
+input_right_btn_label = "Control Pad →"
+input_right_btn = "h0right"
+
+input_l_x_plus_axis_label = "Left Stick →"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis_label = "Left Stick ←"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis_label = "Left Stick ↑"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis_label = "Left Stick ↓"
+input_l_y_minus_axis = "-1"
+
+input_r_x_plus_axis_label = "Right Stick →"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis_label = "Right Stick ←"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis_label = "Right Stick ↑"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis_label = "Right Stick ↓"
+input_r_y_minus_axis = "-3"
+
+input_a_btn_label = "A Button"
+input_a_btn = "1"
+input_b_btn_label = "B Button"
+input_b_btn = "0"
+input_x_btn_label = "X Button"
+input_x_btn = "3"
+input_y_btn_label = "Y Button"
+input_y_btn = "2"
+
+input_select_btn_label = "- Button"
+input_select_btn = "8"
+input_select_btn_label = "+ Button"
+input_start_btn = "9"
+input_menu_toggle_btn = "Capture Button"
+input_menu_toggle_btn = "13"
+
+input_l_btn = "L Button"
+input_l_btn = "4"
+input_l_btn = "R Button"
+input_r_btn = "5"
+input_l2_btn = "ZL Button"
+input_l2_btn = "6"
+input_r2_btn = "ZR Button"
+input_r2_btn = "7"


### PR DESCRIPTION
Config file for the PowerA Wireless Controller for Nintendo SWitch Switch, SKU NSGP0012-01. Set `_label` names from [the official manual](https://www.powera.com/siteassets/user-manuals/nsw/nsw-enhanced-wireless-controller/powera-enhanced-wireless-aa-controller-switch-manual_2021_1643935539.pdf) and mapped based on the joycon config.

To the best of my knowledge and efforts, this controller doesn't advertise a USB VID or PID. However, RetroArch correctly configures the controller using `input_device`, as noted in the config file. Device tested on RetroArch as per Readme.