### PR TITLE
Fix menu button bindings for 8BitDo SN30 Pro

### DIFF
--- a/dinput/8Bitdo_Pro_SN30_BT.cfg
+++ b/dinput/8Bitdo_Pro_SN30_BT.cfg
@@ -1,5 +1,5 @@
 # 8Bitdo SN30 Pro             - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
-# Firmware v1.23              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
+# Firmware v2.02              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
 
 input_driver = "dinput"
 input_device = "Bluetooth Wireless Controller   "
@@ -30,7 +30,7 @@ input_r_x_plus_axis = "+2"
 input_r_x_minus_axis = "-2"
 input_r_y_plus_axis = "+5"
 input_r_y_minus_axis = "-5"
-input_menu_toggle_btn = "2"
+input_menu_toggle_btn = "12"
 
 input_b_btn_label = "B"
 input_y_btn_label = "Y"

--- a/dinput/8Bitdo_Pro_SN30_USB.cfg
+++ b/dinput/8Bitdo_Pro_SN30_USB.cfg
@@ -1,5 +1,5 @@
 # 8Bitdo SN30 Pro             - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
-# Firmware v1.23              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
+# Firmware v2.02              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
 
 input_driver = "dinput"
 input_device = "8Bitdo SN30 Pro"
@@ -30,7 +30,7 @@ input_r_x_plus_axis = "+2"
 input_r_x_minus_axis = "-2"
 input_r_y_plus_axis = "+5"
 input_r_y_minus_axis = "-5"
-input_menu_toggle_btn = "2"
+input_menu_toggle_btn = "12"
 
 input_b_btn_label = "B"
 input_y_btn_label = "Y"

--- a/udev/8Bitdo_Pro_SN30_BT_B.cfg
+++ b/udev/8Bitdo_Pro_SN30_BT_B.cfg
@@ -1,5 +1,5 @@
 # 8Bitdo SN30 Pro (START+B)   - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
-# Firmware v1.23              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
+# Firmware v2.02              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
 
 input_driver = "udev"
 input_device = "8Bitdo SN30 Pro"
@@ -30,7 +30,7 @@ input_r_x_plus_axis = "+2"
 input_r_x_minus_axis = "-2"
 input_r_y_plus_axis = "+3"
 input_r_y_minus_axis = "-3"
-input_menu_toggle_btn = "2"
+input_menu_toggle_btn = "12"
 
 input_b_btn_label = "B"
 input_y_btn_label = "Y"

--- a/udev/8Bitdo_Pro_SN30_USB.cfg
+++ b/udev/8Bitdo_Pro_SN30_USB.cfg
@@ -1,5 +1,5 @@
 # 8Bitdo SN30 Pro             - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
-# Firmware v1.23              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
+# Firmware v2.02              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
 
 input_driver = "udev"
 input_device = "8Bitdo SN30 Pro  8Bitdo SN30 Pro"
@@ -30,7 +30,7 @@ input_r_x_plus_axis = "+2"
 input_r_x_minus_axis = "-2"
 input_r_y_plus_axis = "+3"
 input_r_y_minus_axis = "-3"
-input_menu_toggle_btn = "2"
+input_menu_toggle_btn = "12"
 
 input_b_btn_label = "B"
 input_y_btn_label = "Y"


### PR DESCRIPTION
The menu button binding for this controller (in both the Bluetooth and USB configs) is wrong. I'm not sure if it's always been wrong, or if the button mapping has changed in recent firmware, but in any case, none of the buttons on the controller map to button 2. In fact, the menu button (8BitDo "heart" logo) is button 12.

Should I also update the udev configs? They seem to use the exact same mappings as D-Input, so it might make sense, but I don't have a way of testing with udev right now.