### PR TITLE
Create android/Nintendo - Switch Pro Controller (old).cfg

### DIFF
--- a/android/Nintendo - Switch Pro Controller_(old).cfg
+++ b/android/Nintendo - Switch Pro Controller_(old).cfg
@@ -1,3 +1,4 @@
+# [This version is disabled by default to prevent conflict with the nintendo-hid version. Button layouts are not compatible.]
 # Nintendo Switch Pro Controller (with nintendo-hid)
 
 # input_menu_toggle_btn is bound to the Capture button (Circle label) instead of the the Home button (Home label), because the Home button is bound to Android's Home button.
@@ -16,8 +17,8 @@ input_device = "Pro Controller"
 input_device_display_name = "Nintendo Switch Pro Controller"
 
 # Hex vid/pid: 057e:2009
-input_vendor_id = "1406"
-input_product_id = "8201"
+#input_vendor_id = "1406"
+#input_product_id = "8201"
 
 input_a_btn = "97"
 input_b_btn = "96"

--- a/android/Nintendo - Switch Pro Controller_(old).cfg
+++ b/android/Nintendo - Switch Pro Controller_(old).cfg
@@ -1,0 +1,74 @@
+# Nintendo Switch Pro Controller (with nintendo-hid)
+
+# input_menu_toggle_btn is bound to the Capture button (Circle label) instead of the the Home button (Home label), because the Home button is bound to Android's Home button.
+
+# Android 10 issues for Nintento Switch Pro Controller
+# 
+# The Blutooth connection lags, so it's totally inconvenient to play games
+# 
+# The following keybindnings does not work:
+# Left Analog X+ (Right)
+# Right Analog X+ (Right)
+# Right Analog Y- (Up)
+
+input_driver = "android"
+input_device = "Pro Controller"
+input_device_display_name = "Nintendo Switch Pro Controller"
+
+# Hex vid/pid: 057e:2009
+input_vendor_id = "1406"
+input_product_id = "8201"
+
+input_a_btn = "97"
+input_b_btn = "96"
+input_x_btn = "100"
+input_y_btn = "99"
+input_select_btn = "109"
+input_start_btn = "108"
+input_l_btn = "102"
+input_r_btn = "103"
+input_l2_btn = "104"
+input_r2_btn = "105"
+input_l3_btn = "106"
+input_r3_btn = "107"
+input_menu_toggle_btn = "110"
+
+input_a_btn_label = "A"
+input_b_btn_label = "B"
+input_x_btn_label = "X"
+input_y_btn_label = "Y"
+input_select_btn_label = "Minus"
+input_start_btn_label = "Plus"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "ZL"
+input_r2_btn_label = "ZR"
+input_l3_btn_label = "Left Stick Press"
+input_r3_btn_label = "Right Stick Press"
+input_menu_toggle_btn_label = "Circle"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
+
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"
+input_l_x_plus_axis_label = "Left Analog X+ (Right)"
+input_l_x_minus_axis_label = "Left Analog X- (Left)"
+input_l_y_plus_axis_label = "Left Analog Y+ (Down)"
+input_l_y_minus_axis_label = "Left Analog Y- (Up)"
+input_r_x_plus_axis_label = "Right Analog X+ (Right)"
+input_r_x_minus_axis_label = "Right Analog X- (Left)"
+input_r_y_plus_axis_label = "Right Analog Y+ (Down)"
+input_r_y_minus_axis_label = "Right Analog Y- (Up)"

--- a/android/Nintendo - Switch Pro Controller_(old).cfg
+++ b/android/Nintendo - Switch Pro Controller_(old).cfg
@@ -16,7 +16,6 @@ input_driver = "android"
 input_device = "Pro Controller"
 input_device_display_name = "Nintendo Switch Pro Controller"
 
-# Hex vid/pid: 057e:2009
 #input_vendor_id = "1406"
 #input_product_id = "8201"
 


### PR DESCRIPTION
Generated from
* OS: Android 10
* RA installed via: Google Play
* Retroarch version: 1.9.12

RetroArch:
* Main Menu -> Information -> System Information -> Frontend Identifier: android [default]
* Main Menu -> Information -> System Information -> Frontend OS: Android (v10.0)
* Settings -> Drivers -> Controller -> Controller: android [default]

# IDs
See the conversation about IDs: https://github.com/libretro/retroarch-joypad-autoconfig/pull/944