### PR TITLE
Update and rename 8Bitdo_Arcade_N30_BT.cfg to 8BitDo_Arcade_N30_BT.cfg

### DIFF
--- a/dinput/8BitDo_Arcade_N30_BT.cfg
+++ b/dinput/8BitDo_Arcade_N30_BT.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo N30 Arcade           - http://www.8bitdo.com/     - http://www.8bitdo.com/n30-arcade-stick/
+# 8BitDo N30 Arcade           - http://www.8bitdo.com/     - http://www.8bitdo.com/n30-arcade-stick/
 # Firmware v4.01              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Joystick/8Bitdo_N30_Arcade_Firmware_V4.01.zip
 
 input_driver = "dinput"
 input_device = "Bluetooth Wireless Controller   "
-input_device_display_name = "8Bitdo N30 Arcade"
+input_device_display_name = "8BitDo N30 Arcade"
 
 # Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retroarch.cfg and run RetroArch.
 # Hex vid:pid = 2DC8:1080 -> Decimal vid:pid = 11720:4224


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).