### PR TITLE
Update and rename 8Bitdo_24G_SN30_USB.cfg to 8BitDo_24G_SN30_USB.cfg

### DIFF
--- a/dinput/8BitDo_24G_SN30_USB.cfg
+++ b/dinput/8BitDo_24G_SN30_USB.cfg
@@ -1,4 +1,4 @@
-# 8Bitdo SN30 2.4G            - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30-sf30-2_4g-for-snes-and-sfc-classic-edition/
+# 8BitDo SN30 2.4G            - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30-sf30-2_4g-for-snes-and-sfc-classic-edition/
 # Firmware N/A                - http://support.8bitdo.com/
 
 input_driver = "dinput"


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).