### PR TITLE
Update and rename 8Bitdo_SN30_Modkit_BT.cfg to 8BitDo_SN30_Modkit_BT.cfg

### DIFF
--- a/android/8BitDo_SN30_Modkit_BT.cfg
+++ b/android/8BitDo_SN30_Modkit_BT.cfg
@@ -2,8 +2,8 @@
 # Firmware v5.01              - http://support.8bitdo.com/ 
 
 input_driver = "android"
-input_device = "8Bitdo SN30 Modkit"
-input_device_display_name = "8Bitdo SN30 Modkit"
+input_device = "8BitDo SN30 Modkit"
+input_device_display_name = "8BitDo SN30 Modkit"
 
 # Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retroarch.cfg and run RetroArch.
 # Hex vid:pid = 2DC8:5103 -> Decimal vid:pid = 11720:20739


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).