### PR TITLE
Update and rename 8Bitdo_M30_Modkit_BT.cfg to 8BitDo_M30_Modkit_BT.cfg

### DIFF
--- a/dinput/8BitDo_M30_Modkit_BT.cfg
+++ b/dinput/8BitDo_M30_Modkit_BT.cfg
@@ -3,7 +3,7 @@
 
 input_driver = "dinput"
 input_device = "Bluetooth Wireless Controller   "
-input_device_display_name = "8Bitdo M30 Modkit"
+input_device_display_name = "8BitDo M30 Modkit"
 
 # Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retrorch.cfg and run RetroArch.
 # Hex vid:pid = 2DC8:5101 -> Decimal vid:pid = 11720:20737


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).