### PR TITLE
Update and rename 8Bitdo_N30_Modkit_BT.cfg to 8BitDo_N30_Modkit_BT.cfg

### DIFF
--- a/dinput/8BitDo_N30_Modkit_BT.cfg
+++ b/dinput/8BitDo_N30_Modkit_BT.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo N30 Modkit           - http://www.8bitdo.com/     - http://www.8bitdo.com/mod-kit-for-nes-controller/
+# 8BitDo N30 Modkit           - http://www.8bitdo.com/     - http://www.8bitdo.com/mod-kit-for-nes-controller/
 # Firmware v5.08              - http://support.8bitdo.com/ 
 
 input_driver = "dinput"
 input_device = "Bluetooth Wireless Controller   "
-input_device_display_name = "8Bitdo N30 Modkit"
+input_device_display_name = "8BitDo N30 Modkit"
 
 # Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retroarch.cfg and run RetroArch.
 # Hex vid:pid = 045E:02E0 -> Decimal vid:pid = 1118:736


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).