### PR TITLE
Update and rename 8Bitdo_N30_USB.cfg to 8BitDo_N30_USB.cfg

### DIFF
--- a/dinput/8BitDo_N30_USB.cfg
+++ b/dinput/8BitDo_N30_USB.cfg
@@ -1,4 +1,4 @@
-# 8Bitdo N30                  - http://www.8bitdo.com/     - http://www.8bitdo.com/n30-f30/
+# 8BitDo N30                  - http://www.8bitdo.com/     - http://www.8bitdo.com/n30-f30/
 # Firmware v4.01              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/N30+F30/N30+F30_Firmware_V4.01.zip
 
 input_driver = "dinput"


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).