### PR TITLE
Update and rename 8Bitdo_SN30_USB.cfg to 8BitDo_SN30_USB.cfg

### DIFF
--- a/android/8BitDo_SN30_USB.cfg
+++ b/android/8BitDo_SN30_USB.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo SN30                 - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30-sf30/
+# 8BitDo SN30                 - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30-sf30/
 # Firmware v4.01              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30+SF30/SN30+SF30_Firmware_V4.01.zip
 
 input_driver = "android"
 input_device = "SNES30             SNES30 Joy    "
-input_device_display_name = "8Bitdo SN30"
+input_device_display_name = "8BitDo SN30"
 
 input_vendor_id = "11720"
 input_product_id = "43808"


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).