### PR TITLE
Update and rename 8Bitdo_SNES30_BT.cfg to 8BitDo_SNES30_BT.cfg

### DIFF
--- a/hid/8BitDo_SNES30_BT.cfg
+++ b/hid/8BitDo_SNES30_BT.cfg
@@ -1,10 +1,10 @@
-# 8Bitdo SNES30               - http://www.8bitdo.com/
+# 8BitDo SNES30               - http://www.8bitdo.com/
 # Firmware v4.10              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30+SF30/SN30+SF30_Firmware_V4.10.zip
 #                             - http://download.8bitdo.com/Manual/Controller/SN30+SF30/SN30+SF30_Manual_V4.pdf
 # This is with the device started in Android (D-Input) mode (Power on with no additional buttons)
 
 input_driver = "hid"
-input_device = "8Bitdo SNES30 GamePad"
+input_device = "8BitDo SNES30 GamePad"
 input_vendor_id = "11720"
 input_product_id = "10304"
 


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).