### PR TITLE
Update and rename 8Bitdo_NES30_Pro.cfg to 8BitDo_NES30_Pro.cfg

### DIFF
--- a/hid/8BitDo_NES30_Pro.cfg
+++ b/hid/8BitDo_NES30_Pro.cfg
@@ -1,10 +1,10 @@
-# 8Bitdo NES30 Pro            - http://www.8bitdo.com/     - http://www.8bitdo.com/n30pro-f30pro/
+# 8BitDo NES30 Pro            - http://www.8bitdo.com/     - http://www.8bitdo.com/n30pro-f30pro/
 # Firmware v4.10              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/N30+F30/N30+F30_Firmware_V4.10.zip
 #                             - http://download.8bitdo.com/Manual/Controller/N30+F30/N30+F30_Manual_V4.pdf
 # This is with the device started in Android (D-Input) mode (Power on with no additional buttons)
 
 input_driver = "hid"
-input_device = "8Bitdo NES30 Pro"
+input_device = "8BitDo NES30 Pro"
 input_vendor_id = "11720"
 input_product_id = "14368"
 


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).