### PR TITLE
Update and rename 8Bitdo NES30 Pro   8Bitdo NES30 Pro.cfg to 8BitDo N…

### DIFF
--- a/sdl2/8BitDo NES30 Pro   8BitDo NES30 Pro.cfg
+++ b/sdl2/8BitDo NES30 Pro   8BitDo NES30 Pro.cfg
@@ -1,6 +1,6 @@
-input_device_display_name = "8Bitdo NES30 Pro"
+input_device_display_name = "8BitDo NES30 Pro"
 input_driver = "sdl2"
-input_device = "8Bitdo NES30 Pro   8Bitdo NES30 Pro"
+input_device = "8BitDo NES30 Pro   8BitDo NES30 Pro"
 input_vendor_id = "8194"
 input_product_id = "36864"
 input_b_btn = "1"


### PR DESCRIPTION
…ES30 Pro   8BitDo NES30 Pro.cfg

Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).