### PR TITLE
Update and rename 8Bitdo_Pro_SF30_BT_B.cfg to 8BitDo_Pro_SF30_BT_B.cfg

### DIFF
--- a/udev/8BitDo_Pro_SF30_BT_B.cfg
+++ b/udev/8BitDo_Pro_SF30_BT_B.cfg
@@ -1,4 +1,4 @@
-# 8Bitdo SF30 Pro (START+B)   - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
+# 8BitDo SF30 Pro (START+B)   - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
 # Firmware v1.23              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
 
 input_driver = "udev"


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).