### PR TITLE
Update and rename 8Bitdo_Pro_SF30_BT_X.cfg to 8BitDo_Pro_SF30_BT_X.cfg

### DIFF
--- a/udev/8BitDo_Pro_SF30_BT_X.cfg
+++ b/udev/8BitDo_Pro_SF30_BT_X.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo SF30 Pro (START+X)   - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
+# 8BitDo SF30 Pro (START+X)   - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
 # Firmware v1.23              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
 
 input_driver = "udev"
-input_device = "8Bitdo SF30 Pro"
-input_device_display_name = "8Bitdo SF30 Pro"
+input_device = "8BitDo SF30 Pro"
+input_device_display_name = "8BitDo SF30 Pro"
 
 # Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
 # Hex vid:pid = 045E:02E0 -> Decimal vid:pid = 1118:736


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).