### PR TITLE
Update and rename 8Bitdo_Pro_SN30_USB.cfg to 8BitDo_Pro_SN30_USB.cfg

### DIFF
--- a/udev/8BitDo_Pro_SN30_USB.cfg
+++ b/udev/8BitDo_Pro_SN30_USB.cfg
@@ -1,4 +1,4 @@
-# 8Bitdo SN30 Pro             - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
+# 8BitDo SN30 Pro             - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30pro-sf30pro/
 # Firmware v2.02              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/SN30pro+SF30pro/SN30pro+SF30pro_Firmware_V1.23.zip
 
 input_driver = "udev"


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).