### PR TITLE
Update and rename 8Bitdo_SN30_GP_USB.cfg to 8BitDo_SN30_GP_USB.cfg

### DIFF
--- a/udev/8BitDo_SN30_GP_USB.cfg
+++ b/udev/8BitDo_SN30_GP_USB.cfg
@@ -3,7 +3,7 @@
 
 input_driver = "udev"
 input_device = "8BitDo SN30 gamepad"
-input_device_display_name = "8Bitdo SN30 GP"
+input_device_display_name = "8BitDo SN30 GP"
 
 # Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
 # Hex vid:pid = 2DC8:9012 -> Decimal vid:pid = 11720:36882


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).