### PR TITLE
Update and rename 8Bitdo_P30_Modkit_BT.cfg to 8BitDo_P30_Modkit_BT.cfg

### DIFF
--- a/udev/8BitDo_P30_Modkit_BT.cfg
+++ b/udev/8BitDo_P30_Modkit_BT.cfg
@@ -1,8 +1,8 @@
 # 8BitDo Mod Kit for Original PlayStation Controller (Start+Cross)             - http://www.8bitdo.com/     - https://shop.8bitdo.com/products/mod-kit-for-original-playstation-controller	- http://support.8bitdo.com/
 
 input_driver = "udev"
-input_device = "8Bitdo P30 Modkit"
-input_device_display_name = "8Bitdo P30 Modkit"
+input_device = "8BitDo P30 Modkit"
+input_device_display_name = "8BitDo P30 Modkit"
 
 # Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
 # Hex vid:pid = 2DC8:5107 -> Decimal vid:pid = 11720:20743


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).