### PR TITLE
Update and rename 8Bitdo_N30_USB.cfg to 8BitDo_N30_USB.cfg

### DIFF
--- a/udev/8BitDo_N30_USB.cfg
+++ b/udev/8BitDo_N30_USB.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo N30                  - http://www.8bitdo.com/     - http://www.8bitdo.com/n30-f30/
+# 8BitDo N30                  - http://www.8bitdo.com/     - http://www.8bitdo.com/n30-f30/
 # Firmware v4.01              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/N30+F30/N30+F30_Firmware_V4.01.zip
 
 input_driver = "udev"
 input_device = "NES30              NES30 Joystick"
-input_device_display_name = "8Bitdo N30"
+input_device_display_name = "8BitDo N30"
 
 # Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
 # Hex vid:pid = 2DC8:AB12 -> Decimal vid:pid = 11720:43794


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).