### PR TITLE
Update and rename 8Bitdo_Arcade_F30_USB.cfg to 8BitDo_Arcade_F30_USB.cfg

### DIFF
--- a/udev/8BitDo_Arcade_F30_USB.cfg
+++ b/udev/8BitDo_Arcade_F30_USB.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo F30 Arcade           - http://www.8bitdo.com/
+# 8BitDo F30 Arcade           - http://www.8bitdo.com/
 # Firmware v1.42              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Joystick/8Bitdo_joy_firmware_V1.42.zip
 
 input_driver = "udev"
-input_device = "8Bitdo JoyStick    8Bitdo Joy    "
-input_device_display_name = "8Bitdo F30 Arcade"
+input_device = "8BitDo JoyStick    8Bitdo Joy    "
+input_device_display_name = "8BitDo F30 Arcade"
 
 # Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
 # Hex vid:pid = 8000:1002 -> Decimal vid:pid = 32768:4098


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).