### PR TITLE
Update and rename 8Bitdo_Arcade_F30_BT.cfg to 8BitDo_Arcade_F30_BT.cfg

### DIFF
--- a/udev/8BitDo_Arcade_F30_BT.cfg
+++ b/udev/8BitDo_Arcade_F30_BT.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo F30 Arcade           - http://www.8bitdo.com/
+# 8BitDo F30 Arcade           - http://www.8bitdo.com/
 # Firmware v1.42              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Joystick/8Bitdo_joy_firmware_V1.42.zip
 
 input_driver = "udev"
-input_device = "8Bitdo Joy"
-input_device_display_name = "8Bitdo F30 Arcade"
+input_device = "8BitDo Joy"
+input_device_display_name = "8BitDo F30 Arcade"
 
 # Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
 # Hex vid:pid = 1080:0009 -> Decimal vid:pid = 4224:9


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).