### PR TITLE
Update and rename 8Bitdo_24G_SF30_USB.cfg to 8BitDo_24G_SF30_USB.cfg

### DIFF
--- a/udev/8BitDo_24G_SF30_USB.cfg
+++ b/udev/8BitDo_24G_SF30_USB.cfg
@@ -1,9 +1,9 @@
-# 8Bitdo SF30 2.4G            - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30-sf30-2_4g-for-snes-and-sfc-classic-edition/
+# 8BitDo SF30 2.4G            - http://www.8bitdo.com/     - http://www.8bitdo.com/sn30-sf30-2_4g-for-snes-and-sfc-classic-edition/
 # Firmware N/A                - http://support.8bitdo.com/
 
 input_driver = "udev"
-input_device = "8Bitdo 8Bitdo SF30 Wireless Controller"
-input_device_display_name = "8Bitdo SF30 2.4G"
+input_device = "8BitDo 8Bitdo SF30 Wireless Controller"
+input_device_display_name = "8BitDo SF30 2.4G"
 
 # Hex vid:pid is found using "dmesg -w" or "tail -f /var/log/syslog" and converted to Decimal using http://www.binaryhexconverter.com/hex-to-decimal-converter
 # Hex vid:pid = 2DC8:3001 -> Decimal vid:pid = 11720:12289


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).