### PR TITLE
Update and rename 8Bitdo_Pro_N30_USB.cfg to 8BitDo_Pro_N30_USB.cfg

### DIFF
--- a/udev/8BitDo_Pro_N30_USB.cfg
+++ b/udev/8BitDo_Pro_N30_USB.cfg
@@ -1,4 +1,4 @@
-# 8Bitdo N30 Pro              - http://www.8bitdo.com/     - http://www.8bitdo.com/n30pro-f30pro/
+# 8BitDo N30 Pro              - http://www.8bitdo.com/     - http://www.8bitdo.com/n30pro-f30pro/
 # Firmware v4.01              - http://support.8bitdo.com/ - http://download.8bitdo.com/Firmware/Controller/N30pro+F30pro/N30pro+F30pro_Firmware_V4.01.zip
 
 input_driver = "udev"


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).