### PR TITLE
Update and rename 8Bitdo_N30_Modkit_BT.cfg to 8BitDo_N30_Modkit_BT.cfg

### DIFF
--- a/xinput/8BitDo_N30_Modkit_BT.cfg
+++ b/xinput/8BitDo_N30_Modkit_BT.cfg
@@ -1,7 +1,7 @@
 # 8BitDo Mod Kit for original NES controller - https://www.8bitdo.com/mod-kit-for-nes-controller/
 input_driver = "xinput"
 input_device = "Bluetooth Wireless Controller   "
-input_device_display_name = "8Bitdo N30 Modkit"
+input_device_display_name = "8BitDo N30 Modkit"
 
 # input_vendor_id = "1118"
 # input_product_id = "736"


### PR DESCRIPTION
Replaced "8Bitdo" (typo for "d") with "8BitDo" (official name).