### PR TITLE
Create Raphnet Dreamcast Controller to USB Adapter (v2).cfg

### DIFF
--- a/dinput/Raphnet Dreamcast Controller to USB Adapter (v2).cfg
+++ b/dinput/Raphnet Dreamcast Controller to USB Adapter (v2).cfg
@@ -1,0 +1,23 @@
+# Raphnet Dreamcast Controller to USB Adapter (v2)
+# https://www.raphnet-tech.com/products/dreamcast_usb_adapter/
+
+input_driver = "dinput"
+input_device = "Dreamcast to USB"
+input_vendor_id = "10395"
+input_product_id = "208"
+input_b_btn = "0"
+input_y_btn = "4"
+input_start_btn = "3"
+input_up_btn = "12"
+input_down_btn = "13"
+input_left_btn = "14"
+input_right_btn = "15"
+input_a_btn = "1"
+input_x_btn = "5"
+input_l2_axis = "+5"
+input_r2_axis = "+2"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_gun_trigger_mbtn = "1"


### PR DESCRIPTION
Added support for the Raphnet Dreamcast Controller to USB Adapter (v2) from https://www.raphnet-tech.com/products/dreamcast_usb_adapter/.