### PR TITLE
sdl: Fix PS5 Controller Product ID

### DIFF
--- a/sdl2/PS5 Controller.cfg
+++ b/sdl2/PS5 Controller.cfg
@@ -2,7 +2,7 @@ input_driver = "sdl2"
 input_device = "PS5 Controller"
 input_device_display_name = "DualSense"
 input_vendor_id = "1356"
-input_product_id = "1476"
+input_product_id = "3302"
 
 input_b_btn = "0"
 input_y_btn = "2"


### PR DESCRIPTION
replaced
input_product_id = "1476"

with
input_product_id = "3302"

Reference:
* RetroArch Flatpak uses SDL2 by default and generated "input_product_id = "3302"" via "Settings -> Input -> Port 1 Binds -> Save Controller Profile"
* `input_product_id = "1476"` is the product ID for [PS4 Controller.cfg](https://github.com/libretro/retroarch-joypad-autoconfig/blob/master/sdl2/PS4%20Controller.cfg).