### PR TITLE
udev: Add RetroUSB N64 RetroPort

### DIFF
--- a/udev/RetroUSB-N64-RetroPort.cfg
+++ b/udev/RetroUSB-N64-RetroPort.cfg
@@ -1,0 +1,32 @@
+# https://www.retrousb.com/product_info.php?cPath=21&products_id=82&osCsid=d1511c0e801bd16feddd987fb03be95f
+input_device_display_name = "retroUSB N64 RetroPort"
+input_device = "Brain Actuated Technologies N64 RetroPort"
+input_driver = "udev"
+
+# Hex vid:pid = 1234:0004 -> Decimal vid:pid = 4660:4
+input_vendor_id = "4660"
+input_product_id = "4"
+
+# In Retroarch: settings -> input -> analog sensitivity = 1.5
+# Make sure to save a core remap for your in game buttons as well. Retroarch will not map them correctly by default
+# You can check your settings with this rom https://github.com/sanni/controllertest/blob/master/N64-Port/controllertest.v64
+input_a_btn = "7"
+input_b_btn = "6"
+input_x_btn = "9"
+input_y_btn = "6"
+input_start_btn = "4"
+input_up_btn = "3"
+input_down_btn = "2"
+input_left_btn = "1"
+input_right_btn = "0"
+input_l_btn = "13"
+input_r_btn = "12"
+input_l2_btn = "5"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_btn = "8"
+input_r_x_minus_btn = "9"
+input_r_y_plus_btn = "10"
+input_r_y_minus_btn = "11"


### PR DESCRIPTION
Add mapping for [USB N64 Retroport](https://www.retrousb.com/product_info.php?cPath=21&products_id=82&osCsid=d1511c0e801bd16feddd987fb03be95f). Verified there are no conflicting vendor and product pids