### PR TITLE
udev: Fix RetroUSB N64 Y and X buttons to be consistent with B and A button layout

### DIFF
--- a/udev/RetroUSB-N64-RetroPort.cfg
+++ b/udev/RetroUSB-N64-RetroPort.cfg
@@ -7,13 +7,16 @@ input_driver = "udev"
 input_vendor_id = "4660"
 input_product_id = "4"
 
-# In Retroarch: settings -> input -> analog sensitivity = 1.5
 # Make sure to save a core remap for your in game buttons as well. Retroarch will not map them correctly by default
-# You can check your settings with this rom https://github.com/sanni/controllertest/blob/master/N64-Port/controllertest.v64
+# In Mupen64Plus-Next core options -> PakController Settings -> Analog Sensitivity = 150
+# Optional: The Mupen64Plus-Next options to 150 are not enough to get the control stick 100% as accurate as an original N64 controller
+# You have to add additional sensitivity in Retroarch under settings -> input -> analog sensitivity = 1.1
+# You can check your control stick settings with this rom https://github.com/sanni/controllertest/blob/master/N64-Port/controllertest.v64
+
 input_a_btn = "7"
 input_b_btn = "6"
-input_x_btn = "9"
-input_y_btn = "6"
+input_x_btn = "10"
+input_y_btn = "9"
 input_start_btn = "4"
 input_up_btn = "3"
 input_down_btn = "2"


### PR DESCRIPTION
Minor update to RetroUSB N64 adapter config. The Y and X buttons are now mapped to C buttons above B and A respectively. This is a more consistent layout even though Y and X buttons are not used in N64 games. Just in case you need them.

The comment also suggest a better fix for control stick sensitivity. Sensitivity changes are kept to the Mupen64 core for the most part instead of implementing a global change for all cores