### PR TITLE
[DInput] Add Retro Fighter Brawler64 support

### DIFF
--- a/dinput/Wireless Gamepad.cfg
+++ b/dinput/Wireless Gamepad.cfg
@@ -33,7 +33,7 @@ input_r_y_minus_btn = "11"
 
 input_menu_toggle_btn = "12"
 
----------------------------------------
+# Labels
 
 input_b_btn_label = "A"
 input_y_btn_label = "B"

--- a/dinput/Wireless Gamepad.cfg
+++ b/dinput/Wireless Gamepad.cfg
@@ -1,0 +1,65 @@
+input_device_display_name = "Retro Fighter Brawler64 Wireless Gamepad"
+input_driver = "dinput"
+input_device = "Wireless Gamepad"
+input_vendor_id = "1406"
+input_product_id = "8201"
+
+input_b_btn = "0"
+input_y_btn = "1"
+input_a_btn = "1"
+
+input_select_btn = "8"
+input_start_btn = "9"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_l_btn = "4"
+input_r_btn = "5"
+input_l2_btn = "6"
+input_r2_btn = "7"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+
+input_r_x_minus_btn = "3"
+input_r_x_plus_btn = "10"
+input_r_y_plus_btn = "2"
+input_r_y_minus_btn = "11"
+
+input_menu_toggle_btn = "12"
+
+---------------------------------------
+
+input_b_btn_label = "A"
+input_y_btn_label = "B"
+input_a_btn_label = "B (Retroarch Menu - Go back)"
+
+input_select_btn_label = "Minus"
+input_start_btn_label = "Start"
+
+input_up_btn_label = "D-pad Up"
+input_down_btn_label = "D-pad Down"
+input_left_btn_label = "D-pad Left"
+input_right_btn_label = "D-pad Right"
+
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "ZL"
+input_r2_btn_label = "ZR (Retroarch Menu: Scroll Down)"
+
+input_l_y_minus_axis_label = "Analog Axis Up"
+input_l_y_plus_axis_label = "Analog Axis Down"
+input_l_x_minus_axis_label = "Analog Axis Left"
+input_l_x_plus_axis_label = "Analog Axis Right"
+
+input_r_y_minus_btn_label = "C Up"
+input_r_y_plus_btn_label = "C Down"
+input_r_x_minus_btn_label = "C Left"
+input_r_x_plus_btn_label = "C Right"
+
+input_menu_toggle_btn_label = "Home"


### PR DESCRIPTION
Retro Fighters Brawler64 Wireless Gamepad
UPC: 850046080067


The physical B button shares 2 functions: in game, it serves as the n64 "B" button. in the retroarch menus it serves as a back button, ("A" according to port 1 control menu).  This is the best way i could figure out how to map this gamepad for nintendo 64 games. Only problem is that the "Y" button is also serves for deleting hotkeys in the menu. work around for this is to temporarily set "y" to a C up, down, left, or right button. remove the hotkey errors and then resetting to default controls afterwards in port 1 control.