### PR TITLE
sdl2: Add PS5 Controller note for L2/R2

### DIFF
--- a/sdl2/PS5 Controller.cfg
+++ b/sdl2/PS5 Controller.cfg
@@ -16,6 +16,12 @@ input_a_btn = "1"
 input_x_btn = "3"
 input_l_btn = "9"
 input_r_btn = "10"
+# Note 2024-07-08 :
+#   See https://github.com/libretro/RetroArch/issues/6920
+#   RetroArch's in-app feature to create autoconfig files is flawed and will attempt to create the 2 lines :
+#     input_l2_btn = "6"
+#     input_r2_btn = "7"
+#   Those 2 lines are a downgrade from the 2 following lines which additionally allow l2/r2 to be polled as analog axes :
 input_l2_axis = "+4"
 input_r2_axis = "+5"
 input_l3_btn = "7"


### PR DESCRIPTION
Added comments and a bug report link that L2/R2 have been manually edited due to a RetroArch bug.