### PR TITLE
udev: Add PowerA Xbox X/S Wired Controller

### DIFF
--- a/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint-xone.cfg
+++ b/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint-xone.cfg
@@ -1,0 +1,94 @@
+input_driver = "udev"
+
+# The value of "input_device" changes when using the 'xone' driver
+# https://github.com/medusalix/xone
+input_device = "Microsoft Xbox Controller"
+
+input_device_display_name = "PowerA Enhanced Wired Controller for Xbox Series X|S - Blue Hint"
+
+input_vendor_id = "8406"
+input_product_id = "8213"
+
+# Directional pad (D-pad)
+input_up_btn = "h0up"
+input_up_btn_label = "D-pad Up"
+
+input_down_btn = "h0down"
+input_down_btn_label = "D-pad Down"
+
+input_left_btn = "h0left"
+input_left_btn_label = "D-pad Left"
+
+input_right_btn = "h0right"
+input_right_btn_label = "D-pad Right"
+
+# ABXY Buttons
+input_a_btn = "1"
+input_a_btn_label = "B"
+
+input_b_btn = "0"
+input_b_btn_label = "A"
+
+input_x_btn = "3"
+input_x_btn_label = "X"
+
+input_y_btn = "2"
+input_y_btn_label = "Y"
+
+# Start/Select
+input_start_btn = "6"
+input_start_btn_label = "Menu"
+
+input_select_btn = "7"
+input_select_btn_label = "View"
+
+# Shoulder
+input_l_btn = "4"
+input_l_btn_label = "LB"
+
+input_r_btn = "5"
+input_r_btn_label = "RB"
+
+# Trigger
+input_l2_axis = "+2"
+input_l2_axis_label = "LT"
+
+input_r2_axis = "+5"
+input_r2_axis_label = "RT"
+
+# Thumb
+input_l3_btn = "9"
+input_l3_btn_label = "Left Thumb"
+
+input_r3_btn = "10"
+input_r3_btn_label = "Right Thumb"
+
+# Left Analog
+input_l_y_minus_axis = "-1"
+input_l_y_minus_axis_label = "Left Analog Y- (up)"
+
+input_l_y_plus_axis = "+1"
+input_l_y_plus_axis_label = "Left Analog Y+ (down)"
+
+input_l_x_minus_axis = "-0"
+input_l_x_minus_axis_label = "Left Analog X- (left)"
+
+input_l_x_plus_axis = "+0"
+input_l_x_plus_axis_label = "Left Analog X+ (right)"
+
+# Right Analog
+input_r_y_minus_axis = "-4"
+input_r_y_minus_axis_label = "Right Analog Y- (up)"
+
+input_r_y_plus_axis = "+4"
+input_r_y_plus_axis_label = "Right Analog Y+ (down)"
+
+input_r_x_minus_axis = "-3"
+input_r_x_minus_axis_label = "Right Analog X- (left)"
+
+input_r_x_plus_axis = "+3"
+input_r_x_plus_axis_label = "Right Analog X+ (right)"
+
+# Guide Button
+input_menu_toggle_btn = "8"
+input_menu_toggle_btn_label = "Guide"

--- a/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint-xone.cfg
+++ b/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint-xone.cfg
@@ -30,10 +30,10 @@ input_b_btn = "0"
 input_b_btn_label = "A"
 
 input_x_btn = "3"
-input_x_btn_label = "X"
+input_x_btn_label = "Y"
 
 input_y_btn = "2"
-input_y_btn_label = "Y"
+input_y_btn_label = "X"
 
 # Start/Select
 input_start_btn = "6"

--- a/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint.cfg
+++ b/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint.cfg
@@ -27,10 +27,10 @@ input_b_btn = "0"
 input_b_btn_label = "A"
 
 input_x_btn = "3"
-input_x_btn_label = "X"
+input_x_btn_label = "Y"
 
 input_y_btn = "2"
-input_y_btn_label = "Y"
+input_y_btn_label = "X"
 
 # Start/Select
 input_start_btn = "6"

--- a/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint.cfg
+++ b/udev/PowerA_Enhanced_Wired_Controller_For_Xbox_Series_X_S_Blue_Hint.cfg
@@ -1,0 +1,91 @@
+input_driver = "udev"
+
+input_device = "Generic X-Box pad"
+input_device_display_name = "PowerA Enhanced Wired Controller for Xbox Series X|S - Blue Hint"
+
+input_vendor_id = "8406"
+input_product_id = "8213"
+
+# Directional pad (D-pad)
+input_up_btn = "h0up"
+input_up_btn_label = "D-pad Up"
+
+input_down_btn = "h0down"
+input_down_btn_label = "D-pad Down"
+
+input_left_btn = "h0left"
+input_left_btn_label = "D-pad Left"
+
+input_right_btn = "h0right"
+input_right_btn_label = "D-pad Right"
+
+# ABXY Buttons
+input_a_btn = "1"
+input_a_btn_label = "B"
+
+input_b_btn = "0"
+input_b_btn_label = "A"
+
+input_x_btn = "3"
+input_x_btn_label = "X"
+
+input_y_btn = "2"
+input_y_btn_label = "Y"
+
+# Start/Select
+input_start_btn = "6"
+input_start_btn_label = "Menu"
+
+input_select_btn = "7"
+input_select_btn_label = "View"
+
+# Shoulder
+input_l_btn = "4"
+input_l_btn_label = "LB"
+
+input_r_btn = "5"
+input_r_btn_label = "RB"
+
+# Trigger
+input_l2_axis = "+2"
+input_l2_axis_label = "LT"
+
+input_r2_axis = "+5"
+input_r2_axis_label = "RT"
+
+# Thumb
+input_l3_btn = "9"
+input_l3_btn_label = "Left Thumb"
+
+input_r3_btn = "10"
+input_r3_btn_label = "Right Thumb"
+
+# Left Analog
+input_l_y_minus_axis = "-1"
+input_l_y_minus_axis_label = "Left Analog Y- (up)"
+
+input_l_y_plus_axis = "+1"
+input_l_y_plus_axis_label = "Left Analog Y+ (down)"
+
+input_l_x_minus_axis = "-0"
+input_l_x_minus_axis_label = "Left Analog X- (left)"
+
+input_l_x_plus_axis = "+0"
+input_l_x_plus_axis_label = "Left Analog X+ (right)"
+
+# Right Analog
+input_r_y_minus_axis = "-4"
+input_r_y_minus_axis_label = "Right Analog Y- (up)"
+
+input_r_y_plus_axis = "+4"
+input_r_y_plus_axis_label = "Right Analog Y+ (down)"
+
+input_r_x_minus_axis = "-3"
+input_r_x_minus_axis_label = "Right Analog X- (left)"
+
+input_r_x_plus_axis = "+3"
+input_r_x_plus_axis_label = "Right Analog X+ (right)"
+
+# Guide Button
+input_menu_toggle_btn = "8"
+input_menu_toggle_btn_label = "Guide"


### PR DESCRIPTION
Full controller name: PowerA Enhanced Wired Controller for Xbox Series X|S - Blue Hint
Includes a separate autoconfig file for the `xone` driver (https://github.com/medusalix/xone)