### PR TITLE
Update Nintendo Switch Pro Controller (old).cfg

### DIFF
--- a/sdl2/Nintendo Switch Pro Controller (old).cfg
+++ b/sdl2/Nintendo Switch Pro Controller (old).cfg
@@ -30,13 +30,16 @@ input_l2_axis = "+4"
 input_r2_axis = "+5"
 input_l3_btn = "7"
 input_r3_btn = "8"
+# input_l_x_plus_axis is manually defined here as RetroArch cannot auto-detect it due to Linux driver limitations. This setting may function if a compatible driver has been manually installed.
 input_l_x_plus_axis = "+0"
 input_l_x_minus_axis = "-0"
 input_l_y_plus_axis = "+1"
 input_l_y_minus_axis = "-1"
+# input_r_x_plus_axis is manually defined here as RetroArch cannot auto-detect it due to Linux driver limitations. This setting may function if a compatible driver has been manually installed.
 input_r_x_plus_axis = "+2"
 input_r_x_minus_axis = "-2"
 input_r_y_plus_axis = "+3"
+# input_r_y_minus_axis is manually defined here as RetroArch cannot auto-detect it due to Linux driver limitations. This setting may function if a compatible driver has been manually installed.
 input_r_y_minus_axis = "-3"
 input_menu_toggle_btn = "5"
 


### PR DESCRIPTION
* input_l_x_plus_axis is manually defined here as RetroArch cannot auto-detect it due to Linux driver limitations. This setting may function if a compatible driver has been manually installed.
* input_r_x_plus_axis is manually defined here as RetroArch cannot auto-detect it due to Linux driver limitations. This setting may function if a compatible driver has been manually installed.
* input_r_y_minus_axis is manually defined here as RetroArch cannot auto-detect it due to Linux driver limitations. This setting may function if a compatible driver has been manually installed.