### PR TITLE
android/Pro Controller.cfg: input_menu_toggle_btn comment

### DIFF
--- a/android/Pro Controller.cfg
+++ b/android/Pro Controller.cfg
@@ -11,6 +11,8 @@
 # connectivity issue in Android 11 and earlier makes the
 # controller useless for gaming.
 # 
+# input_menu_toggle_btn is bound to the Capture button (Circle label) instead of the the Home button (Home label), because the Home button is bound to Android's Home button.
+#
 # Evaluated by David Hedlund.
 
 input_driver = "android"


### PR DESCRIPTION
input_menu_toggle_btn is bound to the Capture button (Circle label) instead of the the Home button (Home label), because the Home button is bound to Android's Home button.