### PR TITLE
docs: Clean up some documenation

### DIFF
--- a/android/Pro Controller.cfg
+++ b/android/Pro Controller.cfg
@@ -1,17 +1,4 @@
-# Nintendo Switch Pro Controller (with nintendo-hid)
-# 
-# Requires Android 12 or later.
-# 
-# This is the first fully working Android autoconfig
-# for Nintendo Switch Pro Controller as far as I know
-# 
-# Disclaimer:
-# The Nintendo Switch Pro Controller has other binding
-# for earliers Android versions. However, the Bluetooth
-# connectivity issue in Android 11 and earlier makes the
-# controller useless for gaming.
-# 
-# Evaluated by David Hedlund.
+# Nintendo Switch Pro Controller for nintendo-hid
 
 input_driver = "android"
 input_device = "Pro Controller"


### PR DESCRIPTION
Attribution occurs through project documentation and commit history, not contributor graffiti