### PR TITLE
Add 8BitDo P30 classic Modkit

### DIFF
--- a/udev/8Bitdo_P30_classic_Modkit_BT.cfg
+++ b/udev/8Bitdo_P30_classic_Modkit_BT.cfg
@@ -1,0 +1,43 @@
+# 8BitDo Mod Kit for Original PlayStation Classic Controller (press X + start to turn on the controller)
+#
+# Device: https://shop.8bitdo.com/products/8bitdo-mod-kit-for-original-playstation-classic-controller
+# Manual: https://download.8bitdo.com/Manual/Mod-Kit/Mod-kit-for-original-playstation-classic-controller.pdf
+
+input_driver = "udev"
+input_device = "8Bitdo P30 classic Modkit"
+input_device_display_name = "8BitDo P30 classic Modkit"
+
+input_vendor_id = "11720"
+input_product_id = "20744"
+
+input_b_btn = "0"
+input_y_btn = "3"
+input_select_btn = "10"
+input_start_btn = "11"
+input_a_btn = "1"
+input_x_btn = "4"
+input_l_btn = "6"
+input_r_btn = "7"
+input_l2_btn = "8"
+input_r2_btn = "9"
+
+input_b_btn_label = "Cross"
+input_y_btn_label = "Square"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_a_btn_label = "Circle"
+input_x_btn_label = "Triangle"
+input_l_btn_label = "L1"
+input_r_btn_label = "R1"
+input_l2_btn_label = "L2"
+input_r2_btn_label = "R2"
+
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"


### PR DESCRIPTION
This will add a profile for the 8BitDo P30 **classic** Modkit, which is quite similar to the P30 Modkit, apart from the `product_id`.

Beyond the unique `product_id`, all settings are identical to the existing profile for the P30 Modkit.