### PR TITLE
sdl2: Add DragonRise Inc. GameCube Controller Adapter

### DIFF
--- a/sdl2/DragonRise Inc. GameCube Controller Adapter.cfg
+++ b/sdl2/DragonRise Inc. GameCube Controller Adapter.cfg
@@ -1,0 +1,63 @@
+# Generic Brandless GameCube Controller Adapter
+# From package and manual: Model/SKU:HS-WU025
+# Label on the bottom: GC Controller Adapter; For SWITCH / WII U / PC; ITEM TO: HS-SW224
+# Has:
+# - 4 GC controller ports
+# - 2 USB plugs (black for data, gray for rumble)
+# - TURBO button
+# - SWITCH / WII U <-> PC toggle
+# Analog axes (main, C, L and R) don't go all the way up to 1.0 on max input.
+# Since per-controller/per-axis sensitivity is not supported, it's recommended to set in retroarch.cfg:
+# input_analog_sensitivity = "1.400000"
+
+input_device_display_name = "GameCube Controller Adapter"
+input_driver = "sdl2"
+input_device = "DragonRise Inc. GameCube Controller Adapter"
+input_vendor_id = "121"
+input_product_id = "6214"
+
+input_a_btn = "1"
+input_b_btn = "2"
+input_x_btn = "0"
+input_y_btn = "3"
+input_l2_axis = "+3"
+input_r2_axis = "+4"
+input_l2_btn = "4"
+input_r2_btn = "5"
+input_start_btn = "9"
+input_r_btn = "7"
+input_up_btn = "12"
+input_down_btn = "14"
+input_left_btn = "15"
+input_right_btn = "13"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "-5"
+input_r_x_minus_axis = "+5"
+input_r_y_plus_axis = "-2"
+input_r_y_minus_axis = "+2"
+
+input_a_btn_label = "A"
+input_b_btn_label = "B"
+input_x_btn_label = "X"
+input_y_btn_label = "Y"
+input_l2_axis_label = "Analog L Trigger"
+input_r2_axis_label = "Analog R Trigger"
+input_l2_btn_label = "L"
+input_r2_btn_label = "R"
+input_start_btn_label = "Start"
+input_r_btn_label = "Z"
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"
+input_l_x_plus_axis_label = "Control Stick Right"
+input_l_x_minus_axis_label = "Control Stick Left"
+input_l_y_plus_axis_label = "Control Stick Down"
+input_l_y_minus_axis_label = "Control Stick Up"
+input_r_x_plus_axis_label = "C-Stick Right"
+input_r_x_minus_axis_label = "C-Stick Left"
+input_r_y_plus_axis_label = "C-Stick Down"
+input_r_y_minus_axis_label = "C-Stick Up"


### PR DESCRIPTION
This is a Generic Brand-less GameCube Controller Adapter.

Unfortunately the axes don't go up to 1.0 on max input, and per-axis/per-controller sensitivity is not supported in the file, so a recommendation for global sensitivity is added as a comment.
There's also a description of what this adapter looks like, and the model number.

See:
- #912