### PR TITLE
Update Thrustmaster FGT Rumble 3-in-1.cfg - fix A button label

### DIFF
--- a/udev/Thrustmaster FGT Rumble 3-in-1.cfg
+++ b/udev/Thrustmaster FGT Rumble 3-in-1.cfg
@@ -36,7 +36,7 @@ input_r_y_plus_axis = "+2"
 
 input_b_btn_label = "Action Button Down (2)"
 input_y_btn_label = "Action Button Left (1)"
-input_a_btn_label = "Action Button Down (3)"
+input_a_btn_label = "Action Button Right (3)"
 input_x_btn_label = "Action Button Up (4)"
 
 input_up_btn_label = "D-Pad Up"


### PR DESCRIPTION
Label for A button is wrong. Was duplicate of B/Down button but should be "Right".