### PR TITLE
Linuxraw: Update `Nintendo Switch Pro Controller.cfg`

### DIFF
--- a/linuxraw/Nintendo Switch Pro Controller.cfg
+++ b/linuxraw/Nintendo Switch Pro Controller.cfg
@@ -1,7 +1,7 @@
 input_driver = "linuxraw"
 input_device = "Nintendo Switch Pro Controller"
 input_device_alt1 = "Nintendo Co., Ltd. Pro Controller"
-input_device_alt3 = "Pro Controller"
+input_device_alt2 = "Pro Controller"
 input_b_btn = "0"
 input_y_btn = "3"
 input_select_btn = "9"


### PR DESCRIPTION
Replaced input_device_alt3 with input_device_alt2 as it was unused