### PR TITLE
Added v2 for bluetooth connection on newest XBox Series X/S controllers (1118:2835)

### DIFF
--- a/udev/Microsoft_X-Box_Series_XS_pad_BT_v2.cfg
+++ b/udev/Microsoft_X-Box_Series_XS_pad_BT_v2.cfg
@@ -5,8 +5,6 @@ input_device_display_name = "Xbox Series X/S Controller (BT)"
 input_vendor_id = "1118"
 input_product_id = "2835"
 
-input_vendor_id = "1118"
-input_product_id = "2835"
 input_b_btn = "0"
 input_y_btn = "3"
 input_select_btn = "10"


### PR DESCRIPTION
The wired connection (1118:2834) already works with `udev/Microsoft_X-Box_Series_XS_pad.cfg`, but using bluetooth changes the product ID from 2834 to 2835 and changes the mappings.