### PR TITLE
dinput: Comment out the IDs of Generic Switch Megadrive Fighting Pad 6B

### DIFF
--- a/dinput/MD_Gen_Fighting_Pad_6B_Switch_Online.cfg
+++ b/dinput/MD_Gen_Fighting_Pad_6B_Switch_Online.cfg
@@ -2,8 +2,8 @@ input_driver = "dinput"
 input_device = "Wireless Gamepad"
 input_device_display_name = "Switch Megadrive Fighting Pad 6B"
 
-input_vendor_id = "1406"
-input_product_id = "8215"
+#input_vendor_id = "1406"
+#input_product_id = "8215"
 
 input_b_btn = "0"
 input_y_btn = "1"


### PR DESCRIPTION
This is causing false-positive matches on any Switch pad, as reported here: https://www.reddit.com/r/RetroArch/comments/1nwzh99/comment/nr9z60y/

Commenting the vid/pid should still allow matching on name.