### PR TITLE
udev: Add ASUS ROG Ally X Gamepad

### DIFF
--- a/udev/ASUS ROG Ally X Gamepad.cfg
+++ b/udev/ASUS ROG Ally X Gamepad.cfg
@@ -1,0 +1,37 @@
+# ASUS ROG Ally X Gamepad
+
+input_device_display_name = "ASUS ROG Ally X Gamepad"
+
+input_driver = "udev"
+input_device = "ASUS ROG Ally X Gamepad"
+input_vendor_id = "0b05"
+input_product_id = "1b4c"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_b_btn = "0"
+input_y_btn = "2"
+input_a_btn = "1"
+input_x_btn = "3"
+input_l_btn = "4"
+input_r_btn = "5"
+input_select_btn = "6"
+input_start_btn = "7"
+
+input_l2_axis = "+2"
+input_r2_axis = "+5"
+input_l3_btn = "9"
+input_r3_btn = "10"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+
+input_r_x_plus_axis = "+3"
+input_r_x_minus_axis = "-3"
+input_r_y_plus_axis = "+4"
+input_r_y_minus_axis = "-4"


### PR DESCRIPTION
Add the ASUS ROG Ally X Gamepad. This device uses the not-yet-upstreamed "hid-asus-ally" Linux module that multiple distros like for example Jovian use.