### PR TITLE
udev: Add Mayflash Nintendo 64 Controller Adapter

### DIFF
--- a/udev/Mayflash_N64_Controller_Adapter.cfg
+++ b/udev/Mayflash_N64_Controller_Adapter.cfg
@@ -1,6 +1,6 @@
 # Mayflash Nintendo 64 Controller Adapter for Nintendo Switch 2/Switch/OLED Model, Windows
 input_driver = "udev"
-# input_device = "MAGIC-S PRO"
+input_device = "MAGIC-S PRO"
 input_device_display_name = "Mayflash Nintendo 64 Controller Adapter"
 input_vendor_id = "8406"
 input_product_id = "42768"


### PR DESCRIPTION
This is the adapter: https://www.mayflash.com/product/n64_controller_adapter_mf103.html (from https://www.amazon.de/dp/B089LKCBLG) and firmware is the newest one

I'm not sure why, but for Port 1 the controller reports the input_device as "MAGIC-S PRO" and for Port 2 it's just "Controller", so I commented out the input_device since i think it would just create confusion if someone would plug into an actual MAGIC-S PRO from mayflash (https://www.mayflash.com/product/magic_s_pro_usb_wireless_controller_adapter.html), in case that one would also report as "MAGIC-S PRO"