### PR TITLE
udev: Fix Menu Toggle for XBox One S Wireless Controller

### DIFF
--- a/udev/Xbox One S Wireless Controller.cfg
+++ b/udev/Xbox One S Wireless Controller.cfg
@@ -28,7 +28,7 @@ input_r_x_plus_axis = "+2"
 input_r_x_minus_axis = "-2"
 input_r_y_plus_axis = "+3"
 input_r_y_minus_axis = "-3"
-input_menu_toggle_btn = "8"
+input_menu_toggle_btn = "12"
 
 input_b_btn_label = "A"
 input_y_btn_label = "X"


### PR DESCRIPTION
Fixed the assignment for the Guide button, it was set to `8` but it needs to be set to `12` to work. Nothing on the gamepad seems to have the `8` assignment?