### PR TITLE
android: Add 8BitDo Pro 2 (XInput Bluetooth)

### DIFF
--- a/android/8BitDo_Pro2_XInput_BT.cfg
+++ b/android/8BitDo_Pro2_XInput_BT.cfg
@@ -2,17 +2,17 @@
 # Set the mode switch on the back of the controller to X (XInput).
 #
 # In XInput BT mode the controller spoofs Microsoft VID 0x045E / PID 0x02E0
-# (identical to the Xbox One Wireless Controller).  RetroArch matches the
+# (identical to the Xbox One Wireless Controller). RetroArch matches the
 # "Xbox One Wireless Controller" profile on VID + PID alone (score 60) even
 # though the BT advertised name "8BitDo Pro 2" differs.
 #
 # This profile adds a device-name match on top of VID + PID for a score of 90,
 # winning cleanly.
 #
-# Root cause of Start not working: the real Xbox One controller uses Microsoft's
-# proprietary Bluetooth protocol, where Android maps Menu -> BUTTON_R1 (103).
-# 8BitDo uses HID-over-BT for that button and sends BUTTON_START (108) instead.
-# All other buttons follow the same encoding as a real Xbox One controller.
+# Despite spoofing Xbox One VID/PID, the controller uses standard HID-over-BT
+# keycodes throughout. The Xbox One Wireless Controller profile expects
+# Microsoft's proprietary BT protocol keycodes, which differ for nearly every
+# button except A and B. Verified correct mapping via pad tester.
 #
 # Hex vid:pid = 045E:02E0  ->  Decimal vid:pid = 1118:736
 
@@ -23,21 +23,21 @@ input_vendor_id = "1118"
 input_product_id = "736"
 
 input_b_btn = "96"
-input_y_btn = "98"
-input_select_btn = "102"
+input_a_btn = "97"
+input_y_btn = "99"
+input_x_btn = "100"
+input_select_btn = "109"
 input_start_btn = "108"
 input_up_btn = "h0up"
 input_down_btn = "h0down"
 input_left_btn = "h0left"
 input_right_btn = "h0right"
-input_a_btn = "97"
-input_x_btn = "99"
-input_l_btn = "100"
-input_r_btn = "101"
-input_l2_axis = "+2"
-input_r2_axis = "+3"
-input_l3_btn = "104"
-input_r3_btn = "105"
+input_l_btn = "102"
+input_r_btn = "103"
+input_l2_axis = "+6"
+input_r2_axis = "+7"
+input_l3_btn = "106"
+input_r3_btn = "107"
 input_l_x_plus_axis = "+0"
 input_l_x_minus_axis = "-0"
 input_l_y_plus_axis = "+1"
@@ -49,15 +49,15 @@ input_r_y_minus_axis = "-3"
 input_menu_toggle_btn = "110"
 
 input_b_btn_label = "A"
+input_a_btn_label = "B"
 input_y_btn_label = "X"
+input_x_btn_label = "Y"
 input_select_btn_label = "View"
 input_start_btn_label = "Menu"
 input_up_btn_label = "D-Pad Up"
 input_down_btn_label = "D-Pad Down"
 input_left_btn_label = "D-Pad Left"
 input_right_btn_label = "D-Pad Right"
-input_a_btn_label = "B"
-input_x_btn_label = "Y"
 input_l_btn_label = "Left Bumper"
 input_r_btn_label = "Right Bumper"
 input_l2_axis_label = "Left Trigger"

--- a/android/8BitDo_Pro2_XInput_BT.cfg
+++ b/android/8BitDo_Pro2_XInput_BT.cfg
@@ -1,0 +1,75 @@
+# 8BitDo Pro 2 (XInput Bluetooth mode)
+# Set the mode switch on the back of the controller to X (XInput).
+#
+# In XInput BT mode the controller spoofs Microsoft VID 0x045E / PID 0x02E0
+# (identical to the Xbox One Wireless Controller).  RetroArch matches the
+# "Xbox One Wireless Controller" profile on VID + PID alone (score 60) even
+# though the BT advertised name "8BitDo Pro 2" differs.
+#
+# This profile adds a device-name match on top of VID + PID for a score of 90,
+# winning cleanly.
+#
+# Root cause of Start not working: the real Xbox One controller uses Microsoft's
+# proprietary Bluetooth protocol, where Android maps Menu -> BUTTON_R1 (103).
+# 8BitDo uses HID-over-BT for that button and sends BUTTON_START (108) instead.
+# All other buttons follow the same encoding as a real Xbox One controller.
+#
+# Hex vid:pid = 045E:02E0  ->  Decimal vid:pid = 1118:736
+
+input_driver = "android"
+input_device = "8BitDo Pro 2"
+input_device_display_name = "8BitDo Pro 2 (XInput BT)"
+input_vendor_id = "1118"
+input_product_id = "736"
+
+input_b_btn = "96"
+input_y_btn = "98"
+input_select_btn = "102"
+input_start_btn = "108"
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+input_a_btn = "97"
+input_x_btn = "99"
+input_l_btn = "100"
+input_r_btn = "101"
+input_l2_axis = "+2"
+input_r2_axis = "+3"
+input_l3_btn = "104"
+input_r3_btn = "105"
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
+input_menu_toggle_btn = "110"
+
+input_b_btn_label = "A"
+input_y_btn_label = "X"
+input_select_btn_label = "View"
+input_start_btn_label = "Menu"
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"
+input_a_btn_label = "B"
+input_x_btn_label = "Y"
+input_l_btn_label = "Left Bumper"
+input_r_btn_label = "Right Bumper"
+input_l2_axis_label = "Left Trigger"
+input_r2_axis_label = "Right Trigger"
+input_l3_btn_label = "Left Thumb"
+input_r3_btn_label = "Right Thumb"
+input_l_x_plus_axis_label = "Left Analog X+"
+input_l_x_minus_axis_label = "Left Analog X-"
+input_l_y_plus_axis_label = "Left Analog Y+"
+input_l_y_minus_axis_label = "Left Analog Y-"
+input_r_x_plus_axis_label = "Right Analog X+"
+input_r_x_minus_axis_label = "Right Analog X-"
+input_r_y_plus_axis_label = "Right Analog Y+"
+input_r_y_minus_axis_label = "Right Analog Y-"
+input_menu_toggle_btn_label = "Home"


### PR DESCRIPTION
The 8BitDo Pro 2 in XInput BT mode (mode switch set to X) spoofs
Microsoft VID 0x045E / PID 0x02E0, identical to the Xbox One Wireless
Controller. RetroArch matches the existing Xbox One profile on VID+PID
alone (score 60), since the BT advertised name "8BitDo Pro 2" differs
from the Xbox One profile's input_device "Xbox Wireless Controller".

This causes incorrect button mapping throughout: the Xbox One profile
expects Microsoft's proprietary BT protocol keycodes, which differ from
the standard HID-over-BT keycodes 8BitDo actually sends for nearly every
button except A and B. Verified via pad tester.

This profile matches on device name in addition to VID+PID for a total
score of 90, taking priority over the Xbox One profile, and uses the
correct standard HID keycodes throughout.