### PR TITLE
sdl: dinput: Add 8BitDo 64 Bluetooth Controller

### DIFF
--- a/dinput/8BitDo_64_Bluetooth_Controller.cfg
+++ b/dinput/8BitDo_64_Bluetooth_Controller.cfg
@@ -1,0 +1,63 @@
+# 8BitDo 64 Bluetooth Controller        - https://www.8bitdo.com/        - https://www.8bitdo.com/64-controller/
+# Firmware v2.04        -  https://support.8bitdo.com/        -  https://app.8bitdo.com/Ultimate-Software-V2/
+# This is with the device started in Analogue/Windows/Android (D-input) mode.
+
+input_driver = "sdl2"
+input_device = "8BitDo 64 Bluetooth Controller"
+input_device_display_name = "8BitDo 64 Bluetooth Controller"
+
+# Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retroarch.cfg and run RetroArch.
+# Hex vid:pid = 2DC8:3019 -> Decimal vid:pid = 11720:12313
+
+input_vendor_id = "11720"
+input_product_id = "12313"
+
+input_b_btn = "1"
+input_select_btn = "17"
+input_start_btn = "11"
+input_a_btn = "0"
+input_l_btn = "6"
+input_r_btn = "7"
+input_l2_btn = "8"
+input_r2_btn = "9"
+input_l3_btn = "13"
+input_menu_toggle_btn = "12"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_l_x_minus_axis = "-0"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+3"
+input_r_x_minus_axis = "-3"
+input_r_y_plus_axis = "+4"
+input_r_y_minus_axis = "-4"
+input_l_x_plus_axis = "+0"
+input_l_y_plus_axis = "+1"
+
+input_b_btn_label = "B"
+input_select_btn_label = "Star"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "ZL"
+input_r2_btn_label = "ZR"
+input_l3_btn_label = "Analog Stick"
+input_menu_toggle_btn_label = "Heart"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"
+
+input_l_x_plus_axis_label = "Analog Right"
+input_l_x_minus_axis_label = "Analog Left"
+input_l_y_plus_axis_label = "Analog Down"
+input_l_y_minus_axis_label = "Analog Up"
+input_r_x_plus_axis_label = "Right-C"
+input_r_x_minus_axis_label = "Left-C"
+input_r_y_plus_axis_label = "Down-C"
+input_r_y_minus_axis_label = "Up-C"

--- a/sdl2/8BitDo_64_Bluetooth_Controller.cfg
+++ b/sdl2/8BitDo_64_Bluetooth_Controller.cfg
@@ -1,0 +1,63 @@
+# 8BitDo 64 Bluetooth Controller        - https://www.8bitdo.com/        - https://www.8bitdo.com/64-controller/
+# Firmware v2.04        -  https://support.8bitdo.com/        -  https://app.8bitdo.com/Ultimate-Software-V2/
+# This is with the device started in Analogue/Windows/Android (D-input) mode.
+
+input_driver = "sdl2"
+input_device = "8BitDo 64 Bluetooth Controller"
+input_device_display_name = "8BitDo 64 Bluetooth Controller"
+
+# Hex vid:pid and Decimal vid:pid is shown in the "log_verbosity" window, enable "log_verbosity" in retroarch.cfg and run RetroArch.
+# Hex vid:pid = 2DC8:3019 -> Decimal vid:pid = 11720:12313
+
+input_vendor_id = "11720"
+input_product_id = "12313"
+
+input_b_btn = "1"
+input_select_btn = "17"
+input_start_btn = "11"
+input_a_btn = "0"
+input_l_btn = "6"
+input_r_btn = "7"
+input_l2_btn = "8"
+input_r2_btn = "9"
+input_l3_btn = "13"
+input_menu_toggle_btn = "12"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_l_x_minus_axis = "-0"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+3"
+input_r_x_minus_axis = "-3"
+input_r_y_plus_axis = "+4"
+input_r_y_minus_axis = "-4"
+input_l_x_plus_axis = "+0"
+input_l_y_plus_axis = "+1"
+
+input_b_btn_label = "B"
+input_select_btn_label = "Star"
+input_start_btn_label = "Start"
+input_a_btn_label = "A"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "ZL"
+input_r2_btn_label = "ZR"
+input_l3_btn_label = "Analog Stick"
+input_menu_toggle_btn_label = "Heart"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"
+
+input_l_x_plus_axis_label = "Analog Right"
+input_l_x_minus_axis_label = "Analog Left"
+input_l_y_plus_axis_label = "Analog Down"
+input_l_y_minus_axis_label = "Analog Up"
+input_r_x_plus_axis_label = "Right-C"
+input_r_x_minus_axis_label = "Left-C"
+input_r_y_plus_axis_label = "Down-C"
+input_r_y_minus_axis_label = "Up-C"


### PR DESCRIPTION
Adds dinput and sdl2 autoconfiguration profiles for the 8BitDo 64 Bluetooth Controller, connected either by USB or BT (the controller presents itself identically both ways).

Caveat: The controller presents the C-buttons as a pair of analog axes; the Up-C/Down-C and Left-C/Right-C buttons cannot be read simultaneously.

Tested on Windows 11 25H2 (b26200.8037) with RA input driver set to xinput/dinput/sdl2 (xinput uses the dinput profile).