### PR TITLE
xinput: Add button labels to Mayflash Arcade Fightstick F500 xinput

### DIFF
--- a/xinput/MAYFLASH Arcade Fightstick F500 V2.cfg
+++ b/xinput/MAYFLASH Arcade Fightstick F500 V2.cfg
@@ -3,26 +3,26 @@ input_device = "MAYFLASH Arcade Fightstick F500 V2"
 input_device_display_name = "MAYFLASH Universal Arcade Stick F500 V2 (XInput)"
 input_vendor_id = "12068"
 input_product_id = "135"
-#
+
 input_select_btn = "6"
 input_start_btn = "7"
 input_menu_toggle_btn = "8"
-#
+
 input_up_btn = "h0up"
 input_down_btn = "h0down"
 input_left_btn = "h0left"
 input_right_btn = "h0right"
-#
+
 input_y_btn = "2"
 input_x_btn = "3"
 input_b_btn = "0"
 input_a_btn = "1"
-#
+
 input_l_btn = "4"
 input_r_btn = "5"
 input_l2_btn = "+2"
 input_r2_btn = "+5"
-#
+
 input_l_x_plus_axis = "+0"
 input_l_x_minus_axis = "-0"
 input_l_y_plus_axis = "-1"
@@ -31,3 +31,30 @@ input_r_x_plus_axis = "+3"
 input_r_x_minus_axis = "-3"
 input_r_y_plus_axis = "-4"
 input_r_y_minus_axis = "+4"
+
+# button labels
+input_b_btn_label = "A"
+input_y_btn_label = "X"
+input_select_btn_label = "View"
+input_start_btn_label = "Menu"
+input_up_btn_label = "D-Pad Up"
+input_down_btn_label = "D-Pad Down"
+input_left_btn_label = "D-Pad Left"
+input_right_btn_label = "D-Pad Right"
+input_a_btn_label = "B"
+input_x_btn_label = "Y"
+input_l_btn_label = "Left Bumper"
+input_r_btn_label = "Right Bumper"
+input_l2_axis_label = "Left Trigger"
+input_r2_axis_label = "Right Trigger"
+input_l3_btn_label = "Left Thumb"
+input_r3_btn_label = "Right Thumb"
+input_l_x_plus_axis_label = "Left Analog X+"
+input_l_x_minus_axis_label = "Left Analog X-"
+input_l_y_plus_axis_label = "Left Analog Y+"
+input_l_y_minus_axis_label = "Left Analog Y-"
+input_r_x_plus_axis_label = "Right Analog X+"
+input_r_x_minus_axis_label = "Right Analog X-"
+input_r_y_plus_axis_label = "Right Analog Y+"
+input_r_y_minus_axis_label = "Right Analog Y-"
+input_menu_toggle_btn_label = "Guide"


### PR DESCRIPTION
These were missing, as revealed in a discord support session, so I copied them from another xbox pad.