### PR TITLE
android: 8BitDo Ultimate 2C Wired Controller

### DIFF
--- a/android/8Bitdo_Ultimate_2C_Wired_Controller.cfg
+++ b/android/8Bitdo_Ultimate_2C_Wired_Controller.cfg
@@ -1,0 +1,67 @@
+# 8BitDo Ultimate 2C Wired    - https://www.8bitdo.com/     - https://www.8bitdo.com/ultimate-2c-wireless-controller/
+# Firmware v1.09              - https://support.8bitdo.com/ - https://app.8bitdo.com/Ultimate-Software-V2/
+# When connecting to an Android device hold down B, otherwise the gamepad can get recognized as a keyboard instead
+# When reconnecting to a computer you may have to hold X for the updater to recognize the gamepad again and/or to make rumble work again
+
+input_driver = "android"
+input_device = "8BitDo 8BitDo Ultimate 2C Wired Controller"
+input_device_display_name = "8BitDo Ultimate 2C Wired Controller"
+
+input_vendor_id = "11720"
+input_product_id = "12317"
+
+input_b_btn = "96"
+input_y_btn = "99"
+input_select_btn = "109"
+input_start_btn = "108"
+input_a_btn = "97"
+input_x_btn = "100"
+input_l_btn = "102"
+input_r_btn = "103"
+input_l2_btn = "104"
+input_r2_btn = "105"
+input_l3_btn = "106"
+input_r3_btn = "107"
+input_menu_toggle_btn = "110"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
+
+input_b_btn_label = "A"
+input_y_btn_label = "X"
+input_select_btn_label = "Minus"
+input_start_btn_label = "Plus"
+input_a_btn_label = "B"
+input_x_btn_label = "Y"
+input_l_btn_label = "LB"
+input_r_btn_label = "RB"
+input_l2_btn_label = "LT"
+input_r2_btn_label = "RT"
+input_l3_btn_label = "LSB"
+input_r3_btn_label = "RSB"
+input_menu_toggle_btn_label = "Home"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"
+
+input_l_x_plus_axis_label = "LS Right"
+input_l_x_minus_axis_label = "LS Left"
+input_l_y_plus_axis_label = "LS Down"
+input_l_y_minus_axis_label = "LS Up"
+input_r_x_plus_axis_label = "RS Right"
+input_r_x_minus_axis_label = "RS Left"
+input_r_y_plus_axis_label = "RS Down"
+input_r_y_minus_axis_label = "RS Up"


### PR DESCRIPTION
Added an Android gamepad profile for the 8Bitdo Ultimate 2C Wired Controller. Note that when connecting to an Android device the B button has to be held down, otherwise the gamepad may not get recognized properly. It seems that the gamepad remembers what mode it's in, however when reconnecting to a computer X needs to be held down to reset the mode, otherwise the updater doesn't seem to recognize the gamepad and rumble also doesn't work.