### PR TITLE
android: Add Sunxi IR Remote

### DIFF
--- a/android/sunxi-ir-uinput.cfg
+++ b/android/sunxi-ir-uinput.cfg
@@ -1,0 +1,24 @@
+# Allwinner built-in infrared receiver, intended for menu navigation.
+
+input_driver = "android"
+input_device = "sunxi-ir-uinput"
+input_device_display_name = "Allwinner TV Remote (IR)"
+input_device_type = "remote"
+input_vendor_id = "0"
+input_product_id = "0"
+
+input_b_btn = "4"
+input_up_btn = "19"
+input_down_btn = "20"
+input_left_btn = "21"
+input_right_btn = "22"
+input_a_btn = "23"
+input_menu_toggle_btn = "82"
+
+input_b_btn_label = "Back"
+input_up_btn_label = "Up"
+input_down_btn_label = "Down"
+input_left_btn_label = "Left"
+input_right_btn_label = "Right"
+input_a_btn_label = "OK"
+input_menu_toggle_btn_label = "Menu"


### PR DESCRIPTION
## Summary

Add an Android menu-navigation profile for the Allwinner built-in IR receiver
that reports:

```text
Device: sunxi-ir-uinput
VID:    0x0000 / 0
PID:    0x0000 / 0
Source: DPAD | KEYBOARD (0x00000301)
```

The repository already has `sunxi-ir.cfg`, but Android treats
`sunxi-ir-uinput` as a different exact input device, so that profile does not
match this receiver.

## Hardware validation

- Android 10 TV box using an Allwinner H616 SoC.
- Physical bundled IR remote.
- Android's active `/system/usr/keylayout/sunxi-ir-uinput.kl` maps Back,
  D-pad directions, D-pad Center, and Menu to keycodes 4, 19–23, and 82.
- The physical remote was confirmed navigating RetroArch with arrows, OK,
  Back, and Menu.
- The profile deliberately includes only those validated menu functions.
- Repository test result: `No duplicate profiles were found`.

HDMI-CEC is intentionally excluded: on this Android build CEC events are
framework-injected as `deviceId=-1`, `SOURCE_HDMI`, with no physical device
name or VID/PID, so they cannot be represented honestly by a joypad
autoconfiguration profile.
