### PR TITLE
udev: Add 8BitDo SN30 Modkit (BT)

### DIFF
--- a/udev/8Bitdo_SN30_Modkit_BT.cfg
+++ b/udev/8Bitdo_SN30_Modkit_BT.cfg
@@ -1,0 +1,42 @@
+# 8Bitdo SN30 Modkit          - http://www.8bitdo.com/     - https://shop.8bitdo.com/products/8bitdo-mod-kit-for-original-snes-sfc-controller-old-edition
+
+input_driver = "udev"
+input_device = "8BitDo SN30 Modkit"
+input_device_display_name = "8BitDo SNES Modkit"
+
+# Hex vid:pid = 2DC8:5103
+input_vendor_id = "11720"
+input_product_id = "20739"
+
+input_b_btn = "1"
+input_a_btn = "0"
+input_y_btn = "4"
+input_x_btn = "3"
+input_l_btn = "6"
+input_r_btn = "7"
+input_select_btn = "10"
+input_start_btn = "11"
+
+# The D-pad shows up as ABS_X/Y or HAT0 depending on firmware
+# revision; map both.
+input_up_axis = "-1"
+input_down_axis = "+1"
+input_left_axis = "-0"
+input_right_axis = "+0"
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_b_btn_label = "B"
+input_a_btn_label = "A"
+input_y_btn_label = "Y"
+input_x_btn_label = "X"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_up_btn_label = "D-pad Up"
+input_down_btn_label = "D-pad Down"
+input_left_btn_label = "D-pad Left"
+input_right_btn_label = "D-pad Right"


### PR DESCRIPTION
The udev folder covers the M30/N30/P30/S30 mod kits but not the SNES/SFC one.

Button numbering matches the other D-input mode 8BitDo pads (vid:pid 2DC8:5103). The D-pad is mapped as both axes and hat0 since firmware revisions report it differently. Tested over Bluetooth on a Raspberry Pi 4 (kernel 6.6, hid-generic) with RetroArch master - all buttons and D-pad verified in-game.