### PR TITLE
udev: Add PowerA FUSION Pro 4 Wired Controller

### DIFF
--- a/udev/PowerA FUSION Pro 4 Wired Controller.cfg
+++ b/udev/PowerA FUSION Pro 4 Wired Controller.cfg
@@ -1,0 +1,95 @@
+# Bound by the kernel xpad driver, so the evdev layout matches a standard
+# Xbox pad: 11 buttons (BTN_A..BTN_THUMBR), analog triggers on ABS_Z/ABS_RZ,
+# D-pad on ABS_HAT0. The Share button reports KEY_RECORD, which is below
+# BTN_MISC and therefore not exposed as a pad button by the udev driver.
+
+input_driver = "udev"
+
+input_device = "PowerA FUSION Pro 4 Wired Controller"
+
+input_vendor_id = "8406"
+input_product_id = "16395"
+
+# Directional pad (D-pad)
+input_up_btn = "h0up"
+input_up_btn_label = "D-pad Up"
+
+input_down_btn = "h0down"
+input_down_btn_label = "D-pad Down"
+
+input_left_btn = "h0left"
+input_left_btn_label = "D-pad Left"
+
+input_right_btn = "h0right"
+input_right_btn_label = "D-pad Right"
+
+# ABXY Buttons
+input_a_btn = "1"
+input_a_btn_label = "B"
+
+input_b_btn = "0"
+input_b_btn_label = "A"
+
+input_x_btn = "3"
+input_x_btn_label = "Y"
+
+input_y_btn = "2"
+input_y_btn_label = "X"
+
+# Start/Select
+input_start_btn = "7"
+input_start_btn_label = "Menu"
+
+input_select_btn = "6"
+input_select_btn_label = "View"
+
+# Shoulder
+input_l_btn = "4"
+input_l_btn_label = "LB"
+
+input_r_btn = "5"
+input_r_btn_label = "RB"
+
+# Trigger
+input_l2_axis = "+2"
+input_l2_axis_label = "LT"
+
+input_r2_axis = "+5"
+input_r2_axis_label = "RT"
+
+# Thumb
+input_l3_btn = "9"
+input_l3_btn_label = "Left Thumb"
+
+input_r3_btn = "10"
+input_r3_btn_label = "Right Thumb"
+
+# Left Analog
+input_l_y_minus_axis = "-1"
+input_l_y_minus_axis_label = "Left Analog Y- (up)"
+
+input_l_y_plus_axis = "+1"
+input_l_y_plus_axis_label = "Left Analog Y+ (down)"
+
+input_l_x_minus_axis = "-0"
+input_l_x_minus_axis_label = "Left Analog X- (left)"
+
+input_l_x_plus_axis = "+0"
+input_l_x_plus_axis_label = "Left Analog X+ (right)"
+
+# Right Analog
+input_r_y_minus_axis = "-4"
+input_r_y_minus_axis_label = "Right Analog Y- (up)"
+
+input_r_y_plus_axis = "+4"
+input_r_y_plus_axis_label = "Right Analog Y+ (down)"
+
+input_r_x_minus_axis = "-3"
+input_r_x_minus_axis_label = "Right Analog X- (left)"
+
+input_r_x_plus_axis = "+3"
+input_r_x_plus_axis_label = "Right Analog X+ (right)"
+
+# Guide Button
+input_menu_toggle_btn = "8"
+input_menu_toggle_btn_label = "Guide"


### PR DESCRIPTION
Adds a udev autoconfig profile for the **PowerA FUSION Pro 4 Wired Controller** (USB `20d6:400b`). It isn't in the database yet — the existing PowerA entries cover products `2015`, `a711`, `a713` and `ca6d`.

The kernel binds this pad to `xpad`, so its evdev layout is identical to a standard Xbox pad:

- 11 buttons, `BTN_A` (304) … `BTN_THUMBR` (318)
- analog triggers on `ABS_Z` / `ABS_RZ` (0–1023)
- D-pad on `ABS_HAT0X/Y`, sticks on `ABS_X/Y` + `ABS_RX/RY`

The bind values therefore follow the existing `Generic X-Box pad` profile. Button indices were checked against the device's actual evdev codes — the udev driver enumerates `BTN_JOYSTICK`..`KEY_MAX` in ascending keycode order — which gives `input_select_btn = "6"` (`BTN_SELECT`, View) and `input_start_btn = "7"` (`BTN_START`, Menu).

Input descriptor labels match the labels printed on the controller (A/B/X/Y, LB/RB, LT/RT, Menu/View, Guide).

**Tested on hardware:** Arch Linux, RetroArch 1.22.2, udev input driver. The profile is detected and all binds and labels are correct in `Settings > Input > Port 1 Controls`, including the Menu/View buttons and the Guide button hotkey.

**Note:** the Share button reports `KEY_RECORD` (167), which is below `BTN_MISC`, so RetroArch's udev joypad driver does not expose it as a pad button. This affects all Xbox Series pads on Linux rather than this controller specifically, so it's documented in a comment in the file rather than worked around.

`make test` passes locally (no duplicate profiles).
