### PR TITLE
Add 8BitDo Micro controller profile

### DIFF
--- a/udev/8BitDo_Micro.cfg
+++ b/udev/8BitDo_Micro.cfg
@@ -1,0 +1,43 @@
+# 8BitDo Micro         - https://www.8bitdo.com/        - https://www.8bitdo.com/micro/
+# This is with the device started in Android (D-Input) mode (hold - + Up to turn on the controller).
+
+input_driver = "udev"
+input_device = "8BitDo Micro gamepad"
+input_device_display_name = "8BitDo Micro gamepad"
+
+input_vendor_id = "11720"
+input_product_id = "36896"
+
+input_a_btn = "0"
+input_b_btn = "1"
+input_x_btn = "3"
+input_y_btn = "4"
+input_l_btn = "6"
+input_r_btn = "7"
+input_l2_btn = "8"
+input_r2_btn = "9"
+input_select_btn = "10"
+input_start_btn = "11"
+input_menu_toggle_btn = "12"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_a_btn_label = "A"
+input_b_btn_label = "B"
+input_x_btn_label = "X"
+input_y_btn_label = "Y"
+input_select_btn_label = "Select"
+input_start_btn_label = "Start"
+input_l_btn_label = "L"
+input_r_btn_label = "R"
+input_l2_btn_label = "L2"
+input_r2_btn_label = "R2"
+input_menu_toggle_btn_label = "Home"
+
+input_up_btn_label = "Dpad Up"
+input_down_btn_label = "Dpad Down"
+input_left_btn_label = "Dpad Left"
+input_right_btn_label = "Dpad Right"


### PR DESCRIPTION
Adds a udev autoconfig profile for the 8BitDo Micro
in Android (D-Input) mode.

The D-pad is exposed as HAT0X/HAT0Y axes.